### PR TITLE
fix(runner): recover fresh skill output when the backend exits non-zero

### DIFF
--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -146,6 +146,7 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	}
 	var res *hyrum.RunResult
 	var totalCost float64
+	var recoveredSteps []string
 	for _, s := range skillSteps {
 		fmt.Fprintf(os.Stderr, "  [%s]\n", s.name)
 		r, err := runner.RunSkill(ctx, p.h, ws, s.name, s.out)
@@ -155,6 +156,10 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 				return err
 			}
 			continue
+		}
+		if r.BackendError != "" {
+			fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", d.Name, s.name, r.BackendError)
+			recoveredSteps = append(recoveredSteps, s.name)
 		}
 		totalCost += r.CostUSD
 		res = r
@@ -184,15 +189,20 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if p.verify {
 		verify := p.runVerify(ctx, ws, d, latest, gen.Files)
 		meta["verify"] = verify
-		if v, cost, err := p.runValidate(ctx, runner, ws, verify); err != nil {
+		v, cost, recovery, err := p.runValidate(ctx, runner, ws, verify)
+		if err != nil {
 			fmt.Fprintf(os.Stderr, "  validate: %v\n", err)
 		} else if v != nil {
+			if recovery != "" {
+				recoveredSteps = append(recoveredSteps, "hyrum-validate")
+			}
 			meta["validate"] = v.Verdicts
 			totalCost += cost
 			meta["cost_usd"] = totalCost
 			reportVerdicts(v.Verdicts)
 		}
 	}
+	addBackendRecoveries(meta, recoveredSteps)
 	if err := writeJSON(filepath.Join(outDir, "meta.json"), meta); err != nil {
 		return err
 	}
@@ -200,26 +210,37 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	return nil
 }
 
+func addBackendRecoveries(meta map[string]any, steps []string) {
+	if len(steps) == 0 {
+		return
+	}
+	meta["recovered_output"] = true
+	meta["recovered_steps"] = steps
+}
+
 // runValidate stages the verify results and runs the hyrum-validate skill to
 // classify each latest-version failure and flag weak assertions. It returns
 // nil when there is nothing to validate (verify errored or ran no tests).
-func (p *pipeline) runValidate(ctx context.Context, runner hyrum.Runner, ws string, verify []hyrum.VerifyResult) (*hyrum.ValidateResult, float64, error) {
+func (p *pipeline) runValidate(ctx context.Context, runner hyrum.Runner, ws string, verify []hyrum.VerifyResult) (*hyrum.ValidateResult, float64, string, error) {
 	if !anyRan(verify) {
-		return nil, 0, nil
+		return nil, 0, "", nil
 	}
 	if err := writeJSON(filepath.Join(ws, "verify.json"), verify); err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 	fmt.Fprintf(os.Stderr, "  [hyrum-validate]\n")
 	r, err := runner.RunSkill(ctx, p.h, ws, "hyrum-validate", "verdict.json")
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
+	}
+	if r.BackendError != "" {
+		fmt.Fprintf(os.Stderr, "  ! hyrum-validate: %s\n", r.BackendError)
 	}
 	var out hyrum.ValidateResult
 	if err := r.Decode(&out); err != nil {
-		return nil, r.CostUSD, fmt.Errorf("decode verdict.json: %w", err)
+		return nil, r.CostUSD, "", fmt.Errorf("decode verdict.json: %w", err)
 	}
-	return &out, r.CostUSD, nil
+	return &out, r.CostUSD, r.BackendError, nil
 }
 
 // anyRan reports whether at least one version's tests were parsed. A verify

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
+	"github.com/alpha-omega-security/harness"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 )
 
@@ -18,5 +21,77 @@ func TestAnyRan(t *testing.T) {
 	}
 	if !anyRan([]hyrum.VerifyResult{{Error: "x"}, {Version: "2.0", Fail: 1}}) {
 		t.Error("mixed: one ran")
+	}
+}
+
+func TestAddBackendRecoveries(t *testing.T) {
+	meta := map[string]any{}
+	addBackendRecoveries(meta, nil)
+	if len(meta) != 0 {
+		t.Fatalf("clean run changed metadata: %v", meta)
+	}
+
+	addBackendRecoveries(meta, []string{"hyrum-usage", "hyrum-validate"})
+	if got := meta["recovered_output"]; got != true {
+		t.Errorf("recovered_output = %v", got)
+	}
+	steps, ok := meta["recovered_steps"].([]string)
+	if !ok || len(steps) != 2 || steps[0] != "hyrum-usage" || steps[1] != "hyrum-validate" {
+		t.Errorf("recovered_steps = %v", meta["recovered_steps"])
+	}
+	if _, ok := meta["backend_error"]; ok {
+		t.Error("raw backend error must not be persisted")
+	}
+}
+
+type recoveredRunner struct {
+	output json.RawMessage
+}
+
+func (r recoveredRunner) RunSkill(context.Context, harness.Harness, string, string, string) (*hyrum.RunResult, error) {
+	output := r.output
+	if output == nil {
+		output = json.RawMessage(`{"verdicts":[{"test":"t","status":"weak","action":"strengthen","reasoning":"r"}]}`)
+	}
+	return &hyrum.RunResult{
+		Output:       output,
+		CostUSD:      0.25,
+		BackendError: "backend exited non-zero after writing fresh output",
+	}, nil
+}
+
+func TestRunValidateReturnsRecovery(t *testing.T) {
+	p := &pipeline{h: harness.ClaudeHarness{}}
+	out, cost, recovery, err := p.runValidate(context.Background(), recoveredRunner{}, t.TempDir(), []hyrum.VerifyResult{{Pass: 1}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out == nil || len(out.Verdicts) != 1 {
+		t.Fatalf("validate output = %+v", out)
+	}
+	if cost != 0.25 {
+		t.Errorf("cost = %v", cost)
+	}
+	if recovery == "" {
+		t.Fatal("validate recovery was discarded")
+	}
+}
+
+func TestRunValidateDecodeFailureDoesNotReturnRecovery(t *testing.T) {
+	p := &pipeline{h: harness.ClaudeHarness{}}
+	out, _, recovery, err := p.runValidate(
+		context.Background(),
+		recoveredRunner{output: json.RawMessage(`{"verdicts":"bad"}`)},
+		t.TempDir(),
+		[]hyrum.VerifyResult{{Pass: 1}},
+	)
+	if err == nil {
+		t.Fatal("want decode error")
+	}
+	if out != nil {
+		t.Fatalf("discarded validation output = %+v", out)
+	}
+	if recovery != "" {
+		t.Fatalf("discarded output reported as recovered: %q", recovery)
 	}
 }

--- a/docs/consumer-ci.md
+++ b/docs/consumer-ci.md
@@ -20,6 +20,13 @@ The generated files are plain `node:test` (or pytest, or `go test`) files
 under `tests/hyrum/<dep>/from_<repo>/` with a `meta.json` recording the
 baseline version and generation inputs.
 
+If a backend exits non-zero after writing a fresh, usable output artifact,
+Hyrum preserves that output and records `recovered_output: true` plus the
+affected `recovered_steps` in `meta.json`. Raw backend output is not persisted.
+The expected artifact is removed before every invocation, so output from an
+earlier run cannot be recovered by mistake. Cancellation and provider-account
+failures remain fatal even when an artifact exists.
+
 ## On each update PR
 
 ```yaml

--- a/internal/hyrum/container.go
+++ b/internal/hyrum/container.go
@@ -2,7 +2,6 @@ package hyrum
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -67,6 +66,10 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 	}
 
 	absWork, err := filepath.Abs(ws)
+	if err != nil {
+		return nil, err
+	}
+	outputPath, err := prepareOutput(absWork, outputFile)
 	if err != nil {
 		return nil, err
 	}
@@ -141,22 +144,15 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 	waitErr := cmd.Wait()
 	_ = pw.Close()
 	<-done
+	var runErr error
 	if waitErr != nil {
 		if detail := h.AccountErrorText(stderr.String()); detail != "" {
-			return nil, fmt.Errorf("%s: %s", h.Binary(), detail)
+			runErr = &harness.AccountError{Detail: detail}
+		} else {
+			runErr = fmt.Errorf("%s run: %w: %s", runtime, waitErr, strings.TrimSpace(stderr.String()))
 		}
-		return nil, fmt.Errorf("%s run: %w: %s", runtime, waitErr, strings.TrimSpace(stderr.String()))
 	}
-
-	b, err := os.ReadFile(filepath.Join(absWork, outputFile))
-	if err != nil {
-		return nil, fmt.Errorf("read %s: %w (skill did not write output)", outputFile, err)
-	}
-	if !json.Valid(b) {
-		return nil, fmt.Errorf("%s is not valid JSON", outputFile)
-	}
-	res.Output = b
-	return res, nil
+	return finishRun(ctx, res, outputPath, name, outputFile, runErr)
 }
 
 // runArgs builds the container-run argv up to and including the image name.

--- a/internal/hyrum/container_test.go
+++ b/internal/hyrum/container_test.go
@@ -1,6 +1,10 @@
 package hyrum
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -49,4 +53,107 @@ func TestContainerRunArgsNoTarget(t *testing.T) {
 func TestHostRunnerSatisfiesRunner(t *testing.T) {
 	var _ Runner = HostRunner{}
 	var _ Runner = ContainerRunner{}
+}
+
+func TestContainerRunnerBackendFailureWithFreshOutputRecovers(t *testing.T) {
+	ws := t.TempDir()
+	outputPath := filepath.Join(ws, "tests.json")
+	t.Setenv("HYRUM_TEST_OUTPUT", outputPath)
+
+	runtime := filepath.Join(t.TempDir(), "fake-container-runtime")
+	script := `#!/bin/sh
+printf '%s' '{"files":[{"path":"test_recovered.js","content":"// recovered\n"}]}' > "$HYRUM_TEST_OUTPUT"
+exit 1
+`
+	if err := os.WriteFile(runtime, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	if err != nil {
+		t.Fatalf("fresh valid output should survive container failure: %v", err)
+	}
+	if res.BackendError == "" {
+		t.Fatal("recovered result did not retain backend error")
+	}
+	var gen GenerateResult
+	if err := res.Decode(&gen); err != nil {
+		t.Fatal(err)
+	}
+	if len(gen.Files) != 1 || gen.Files[0].Path != "test_recovered.js" {
+		t.Fatalf("output = %+v", gen)
+	}
+}
+
+func TestContainerRunnerBackendFailureDoesNotReuseStaleOutput(t *testing.T) {
+	ws := t.TempDir()
+	outputPath := filepath.Join(ws, "tests.json")
+	if err := os.WriteFile(outputPath, []byte(`{"files":[{"path":"stale.js","content":"// stale"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime := filepath.Join(t.TempDir(), "fake-container-runtime")
+	if err := os.WriteFile(runtime, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	if _, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json"); err == nil {
+		t.Fatal("want error rather than stale container output")
+	}
+	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
+		t.Fatalf("stale output was not removed: %v", err)
+	}
+}
+
+func TestContainerRunnerRecoveryDoesNotRetainStderr(t *testing.T) {
+	ws := t.TempDir()
+	outputPath := filepath.Join(ws, "tests.json")
+	t.Setenv("HYRUM_TEST_OUTPUT", outputPath)
+
+	runtime := filepath.Join(t.TempDir(), "fake-container-runtime")
+	script := `#!/bin/sh
+printf '%s' '{"files":[{"path":"test_recovered.js","content":"// recovered\n"}]}' > "$HYRUM_TEST_OUTPUT"
+printf '%s' 'token sk-ant-secret-value-1234 rejected' >&2
+exit 1
+`
+	if err := os.WriteFile(runtime, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	if err != nil {
+		t.Fatalf("fresh valid output should survive container failure: %v", err)
+	}
+	if strings.Contains(res.BackendError, "sk-ant-secret-value-1234") {
+		t.Fatalf("backend warning retained stderr secret: %q", res.BackendError)
+	}
+	if len(res.BackendError) > 256 {
+		t.Fatalf("backend warning is unbounded: %d bytes", len(res.BackendError))
+	}
+}
+
+func TestContainerRunnerAccountErrorIsFatal(t *testing.T) {
+	ws := t.TempDir()
+	outputPath := filepath.Join(ws, "tests.json")
+	t.Setenv("HYRUM_TEST_OUTPUT", outputPath)
+
+	runtime := filepath.Join(t.TempDir(), "fake-container-runtime")
+	script := `#!/bin/sh
+printf '%s' '{"files":[{"path":"test_partial.js","content":"// partial\n"}]}' > "$HYRUM_TEST_OUTPUT"
+printf '%s' 'Credit balance is too low' >&2
+exit 1
+`
+	if err := os.WriteFile(runtime, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	_, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	var accountErr *harness.AccountError
+	if !errors.As(err, &accountErr) {
+		t.Fatalf("want typed account error, got %v", err)
+	}
 }

--- a/internal/hyrum/run.go
+++ b/internal/hyrum/run.go
@@ -3,6 +3,7 @@ package hyrum
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,7 +50,13 @@ type RunResult struct {
 	CostUSD   float64
 	Turns     int
 	SessionID string
+	// BackendError records a non-zero backend exit when the same invocation
+	// still produced a fresh, usable output artifact. It is a categorical,
+	// safe-to-display warning; raw provider output is never stored here.
+	BackendError string
 }
+
+const recoveredBackendError = "backend exited non-zero after writing fresh output"
 
 // Decode unmarshals the skill's output file into v.
 func (r *RunResult) Decode(v any) error {
@@ -84,6 +91,10 @@ func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFi
 		OutputFile:   outputFile,
 		SystemPrompt: headlessSystemPrompt,
 	}
+	outputPath, err := prepareOutput(ws, outputFile)
+	if err != nil {
+		return nil, err
+	}
 
 	// Backends that do not report a price (codex) still report token usage;
 	// fall back to the list-price estimate for the backend's default model so
@@ -111,19 +122,85 @@ func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFi
 		}
 	}
 
-	if err := harness.Run(ctx, h, job, wrapped); err != nil {
-		return nil, err
+	runErr := harness.Run(ctx, h, job, wrapped)
+	return finishRun(ctx, res, outputPath, name, outputFile, runErr)
+}
+
+// prepareOutput removes the expected artifact before invoking a backend. Skill
+// workspaces are intentionally reusable, so this prevents a failed invocation
+// from appearing successful by leaving an older output file in place.
+func prepareOutput(ws, outputFile string) (string, error) {
+	clean := filepath.Clean(outputFile)
+	if outputFile != clean || clean == "." || clean == ".." || clean != filepath.Base(clean) || filepath.IsAbs(clean) {
+		return "", fmt.Errorf("refusing output path %q", outputFile)
+	}
+	path := filepath.Join(ws, clean)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return "", fmt.Errorf("remove stale %s: %w", outputFile, err)
+	}
+	return path, nil
+}
+
+// finishRun reads the artifact written by this invocation. A non-zero backend
+// exit is recoverable only when a fresh, usable JSON artifact exists; otherwise
+// the backend error remains fatal. The backend failure is retained on a
+// successful result so callers do not silently treat a partial run as clean.
+func finishRun(ctx context.Context, res *RunResult, outputPath, skillName, outputFile string, runErr error) (*RunResult, error) {
+	if runErr != nil {
+		var accountErr *harness.AccountError
+		if ctx.Err() != nil || errors.As(runErr, &accountErr) {
+			return nil, runErr
+		}
 	}
 
-	b, err := os.ReadFile(filepath.Join(ws, outputFile))
+	b, err := os.ReadFile(outputPath)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w (skill did not write output)", outputFile, err)
+		outputErr := fmt.Errorf("read %s: %w (skill did not write output)", outputFile, err)
+		if runErr != nil {
+			return nil, fmt.Errorf("%w; %v", runErr, outputErr)
+		}
+		return nil, outputErr
 	}
 	if !json.Valid(b) {
-		return nil, fmt.Errorf("%s is not valid JSON", outputFile)
+		outputErr := fmt.Errorf("%s is not valid JSON", outputFile)
+		if runErr != nil {
+			return nil, fmt.Errorf("%w; %v", runErr, outputErr)
+		}
+		return nil, outputErr
 	}
+	if runErr != nil {
+		if err := validateRecoveredOutput(skillName, b); err != nil {
+			return nil, fmt.Errorf("%w; %v", runErr, err)
+		}
+	}
+
 	res.Output = b
+	if runErr != nil {
+		res.BackendError = recoveredBackendError
+	}
 	return res, nil
+}
+
+func validateRecoveredOutput(skillName string, b []byte) error {
+	switch skillName {
+	case "hyrum-generate":
+		var gen GenerateResult
+		if err := json.Unmarshal(b, &gen); err != nil {
+			return fmt.Errorf("decode recovered generate output: %w", err)
+		}
+		if len(gen.Files) == 0 {
+			return fmt.Errorf("recovered generate output has no files")
+		}
+	case "hyrum-validate":
+		var validate ValidateResult
+		if err := json.Unmarshal(b, &validate); err != nil {
+			return fmt.Errorf("decode recovered validate output: %w", err)
+		}
+		if len(validate.Verdicts) == 0 {
+			return fmt.Errorf("recovered validate output has no verdicts")
+		}
+	}
+	return nil
 }
 
 // WriteFiles writes each generated file under root, refusing paths that escape

--- a/internal/hyrum/run_test.go
+++ b/internal/hyrum/run_test.go
@@ -2,10 +2,13 @@ package hyrum
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/alpha-omega-security/harness"
 )
@@ -19,6 +22,8 @@ type shHarness struct {
 	payload string // JSON body to write to tests.json
 	exit    int
 	noWrite bool
+	stderr  string
+	block   bool
 }
 
 func (h shHarness) Binary() string { return "/bin/sh" }
@@ -27,6 +32,12 @@ func (h shHarness) Args(j harness.Job) []string {
 	var script string
 	if !h.noWrite {
 		script = fmt.Sprintf("printf %%s %q > %q; ", h.payload, j.OutputFile)
+	}
+	if h.stderr != "" {
+		script += fmt.Sprintf("printf %%s %q >&2; ", h.stderr)
+	}
+	if h.block {
+		script += "sleep 30; "
 	}
 	script += fmt.Sprintf("exit %d", h.exit)
 	return []string{"-c", script}
@@ -109,11 +120,153 @@ func TestRunSkillInvalidJSON(t *testing.T) {
 	}
 }
 
-func TestRunSkillBackendFailure(t *testing.T) {
+func TestRunSkillBackendFailureWithFreshOutputRecovers(t *testing.T) {
+	ws := t.TempDir()
+	body := `{"files":[{"path":"test_recovered.js","content":"// recovered\n"}]}`
+	h := shHarness{payload: body, exit: 1}
+	res, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil)
+	if err != nil {
+		t.Fatalf("fresh valid output should survive backend failure: %v", err)
+	}
+	if res.BackendError == "" {
+		t.Fatal("recovered result did not retain backend error")
+	}
+	var gen GenerateResult
+	if err := res.Decode(&gen); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(gen.Files) != 1 || gen.Files[0].Path != "test_recovered.js" {
+		t.Fatalf("output = %+v", gen)
+	}
+}
+
+func TestRunSkillBackendFailureWithoutOutputFails(t *testing.T) {
+	ws := t.TempDir()
+	h := shHarness{exit: 1, noWrite: true}
+	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+		t.Fatal("want error when backend fails without output")
+	}
+}
+
+func TestRunSkillBackendFailureDoesNotReuseStaleOutput(t *testing.T) {
+	ws := t.TempDir()
+	path := filepath.Join(ws, "tests.json")
+	if err := os.WriteFile(path, []byte(`{"files":[{"path":"stale.js","content":"// stale"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h := shHarness{exit: 1, noWrite: true}
+	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+		t.Fatal("want error rather than stale output")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("stale output was not removed: %v", err)
+	}
+}
+
+func TestRunSkillBackendFailureWithInvalidOutputFails(t *testing.T) {
+	ws := t.TempDir()
+	h := shHarness{payload: "not json", exit: 1}
+	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+		t.Fatal("want error when backend fails with invalid output")
+	}
+}
+
+func TestRunSkillBackendFailureWithEmptyGenerateOutputFails(t *testing.T) {
+	for _, payload := range []string{`{"files":[]}`, `{}`, `null`} {
+		t.Run(payload, func(t *testing.T) {
+			ws := t.TempDir()
+			h := shHarness{payload: payload, exit: 1}
+			if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+				t.Fatal("want error when failed backend writes no generated files")
+			}
+		})
+	}
+}
+
+func TestRunSkillBackendFailureWithRenamedEmptyGenerateOutputFails(t *testing.T) {
 	ws := t.TempDir()
 	h := shHarness{payload: `{"files":[]}`, exit: 1}
-	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
-		t.Fatal("want error on non-zero exit")
+	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "generated.json", nil); err == nil {
+		t.Fatal("want generate recovery policy to be independent of output filename")
+	}
+}
+
+func TestRunSkillBackendFailureWithEmptyValidateOutputFails(t *testing.T) {
+	for _, payload := range []string{`{"verdicts":[]}`, `{}`, `null`} {
+		t.Run(payload, func(t *testing.T) {
+			ws := t.TempDir()
+			h := shHarness{payload: payload, exit: 1}
+			if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-validate", "verdict.json", nil); err == nil {
+				t.Fatal("want error when failed validation backend writes no verdicts")
+			}
+		})
+	}
+}
+
+func TestRunSkillBackendFailureWithValidateVerdictRecovers(t *testing.T) {
+	ws := t.TempDir()
+	body := `{"verdicts":[{"test":"t","status":"weak","action":"strengthen","reasoning":"r"}]}`
+	h := shHarness{payload: body, exit: 1}
+	res, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-validate", "verdict.json", nil)
+	if err != nil {
+		t.Fatalf("usable validate output should survive backend failure: %v", err)
+	}
+	if res.BackendError == "" {
+		t.Fatal("recovered result did not retain backend warning")
+	}
+	var out ValidateResult
+	if err := res.Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Verdicts) != 1 {
+		t.Fatalf("verdicts = %+v", out.Verdicts)
+	}
+}
+
+func TestRunSkillCancelledRunIsFatal(t *testing.T) {
+	ws := t.TempDir()
+	body := `{"files":[{"path":"test_partial.js","content":"// partial\n"}]}`
+	h := shHarness{payload: body, block: true}
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	if _, err := RunSkillWithEmit(ctx, h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+		t.Fatal("want cancellation to remain fatal despite fresh output")
+	}
+}
+
+func TestRunSkillAccountErrorIsFatal(t *testing.T) {
+	ws := t.TempDir()
+	body := `{"files":[{"path":"test_partial.js","content":"// partial\n"}]}`
+	h := shHarness{payload: body, stderr: "Credit balance is too low", exit: 1}
+
+	_, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil)
+	var accountErr *harness.AccountError
+	if !errors.As(err, &accountErr) {
+		t.Fatalf("want typed account error, got %v", err)
+	}
+}
+
+func TestPrepareOutputRejectsSymlinkedDirectory(t *testing.T) {
+	ws := t.TempDir()
+	outside := t.TempDir()
+	victim := filepath.Join(outside, "victim.json")
+	if err := os.WriteFile(victim, []byte("important"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(ws, "sub")); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := prepareOutput(ws, filepath.Join("sub", "victim.json")); err == nil {
+		t.Fatal("want nested output path rejected")
+	}
+	b, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("outside file was removed: %v", err)
+	}
+	if !strings.EqualFold(string(b), "important") {
+		t.Fatalf("outside file changed: %q", b)
 	}
 }
 


### PR DESCRIPTION
HostRunner and ContainerRunner returned as soon as the backend exited non-zero, without reading the skill's output file. A real run lost a complete, schema-checked tests.json that way: the backend wrote the artifact, then hit its maximum turn count, so a finished generation was discarded and had to be paid for again.

Both runners now remove the expected artifact before every invocation and read it after the backend exits, so a non-zero exit is recoverable only when that same invocation left a fresh artifact behind. The boundaries are deliberate: missing, stale, and malformed output stay fatal, as do cancelled runs and provider-account failures, and usability follows each skill's contract — a recovered generation needs at least one file, a recovered validation at least one verdict.

A recovered run is never silently clean: meta.json records recovered_output and the recovered_steps behind it, and the per-step warning is categorical because meta.json is committed to the consumer's repository and raw backend stderr can carry credentials. New regressions cover both runners at each boundary, including under -race, with a fake container runtime standing in for the container path.
