### PR TITLE
feat(gen): load hyrum.yaml configuration from the target repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,39 @@ For codex, `export CODEX_API_KEY=sk-...`. Copilot accepts
 `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`. For opencode, use
 `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` depending on its configured provider.
 
+## Configuration
+
+`hyrum gen` automatically loads `hyrum.yaml` from the analyzed target
+repository's root when that file exists. It does not search parent
+directories. Use `--config <path>` to load a different file; a missing,
+unreadable, malformed, or invalid explicit file is an error, while an absent
+automatic file is not. Configuration is strict: unknown keys and incorrect
+value types are rejected.
+
+The supported settings are `backend`, `out`, `work`, per-skill `models`, and
+per-dependency `baseline` and `skip` values under `deps`. Explicit command-line
+flags take precedence over config, and config takes precedence over built-in
+defaults. Relative `out` paths are rooted at the target repository. For safety,
+`out` in an automatically discovered target configuration must remain inside
+that target; an explicitly supplied `--config` may select an external output
+path.
+
+An automatically discovered config cannot select `work`: that value is ignored
+unless the operator supplies the config with `--config`. `--work` is always
+honored. A relative `work` value from an explicit config is rooted at the
+directory containing that file; absolute paths and `~/...` are accepted.
+
+Dependency overrides may be keyed by manifest name or full purl; a purl entry
+wins for fields also set by a name entry. `skip: true` removes a dependency
+from default generation, but an explicit `--dep` includes it. `baseline`
+changes the version staged, verified, and recorded by Hyrum without modifying
+the target's manifest or lockfile.
+
+Model values are portable `mid`, `high`, or `max` tiers. Each selected backend
+maps the tier to a model through the harness API, so model selection applies
+to individual skills without backend-specific configuration. See
+[`hyrum.sample.yaml`](hyrum.sample.yaml) for the complete schema.
+
 ## Host and container modes
 
 By default the backend runs on the host, so its CLI (`claude`, `codex`, ...)

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/alpha-omega-security/harness"
+	hyrumconfig "github.com/alpha-omega-security/hyrum/internal/config"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
 	"github.com/git-pkgs/clone"
@@ -32,22 +34,47 @@ var skillSteps = []struct {
 	{"hyrum-generate", "tests.json", true},
 }
 
+const (
+	defaultGenBackend = "claude"
+	defaultGenOut     = "tests/hyrum"
+)
+
+type genOptions struct {
+	backend string
+	out     string
+	work    string
+	models  map[string]string
+}
+
+func defaultGenOptions() genOptions {
+	return genOptions{
+		backend: defaultGenBackend,
+		out:     defaultGenOut,
+		work:    filepath.Join(os.TempDir(), "hyrum"),
+	}
+}
+
 // cmdGen runs the generation pipeline for one or more dependencies: stage the
 // context bundle, gather history inputs, then run the usage/history/generate
 // skills in sequence. Without --run it stops after staging so the workspace
 // can be inspected without invoking a backend.
 func cmdGen(ctx context.Context, args []string) error {
 	fs := newFlags("gen")
+	defaults := defaultGenOptions()
 	var deps stringList
 	fs.Var(&deps, "dep", "dependency name to generate for (repeatable); default: all direct runtime deps")
-	out := fs.String("out", "tests/hyrum", "output root for generated tests")
-	work := fs.String("work", filepath.Join(os.TempDir(), "hyrum"), "working directory for clones and skill workspaces")
-	backend := fs.String("backend", "claude", "harness backend: "+harness.Names())
+	configPath := fs.String("config", "", "configuration file (default: <target>/hyrum.yaml when present)")
+	out := fs.String("out", defaults.out, "output root for generated tests")
+	work := fs.String("work", defaults.work, "working directory for clones and skill workspaces")
+	backend := fs.String("backend", defaults.backend, "harness backend: "+harness.Names())
 	run := fs.Bool("run", false, "actually invoke the backend (otherwise stage only)")
 	container := fs.String("container", "", "run the backend in a container using this image (\"default\" for "+hyrum.DefaultRunnerImage+")")
 	verify := fs.Bool("verify", false, "after generating, run the tests against the baseline and latest dep versions and record results in meta.json")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if fs.NArg() > 1 {
+		return fmt.Errorf("unexpected arguments after <path>: %v (flags must precede <path>)", fs.Args()[1:])
 	}
 	path := "."
 	if fs.NArg() > 0 {
@@ -59,19 +86,162 @@ func cmdGen(ctx context.Context, args []string) error {
 		return err
 	}
 
-	selected := selectDeps(t, deps)
-	if len(selected) == 0 {
-		return fmt.Errorf("no dependencies selected (target has %d direct deps across %v)", len(t.Deps), t.Ecosystems())
+	set := visitedFlags(fs)
+	if set["config"] && *configPath == "" {
+		return fmt.Errorf("--config requires a non-empty path")
 	}
-
-	h, err := harness.ByName(*backend)
+	cfg, cfgSource, err := hyrumconfig.Load(t.Path, *configPath)
+	if err != nil {
+		return err
+	}
+	resolved, err := resolveGenOptions(t.Path, cfgSource, set["config"], cfg, genOptions{
+		backend: *backend,
+		out:     *out,
+		work:    *work,
+	}, set)
 	if err != nil {
 		return err
 	}
 
-	p := newPipeline(h, *work, outRoot(t.Path, *out), *run, resolveContainer(*container))
+	selected := selectGenDeps(t, deps, cfg.Deps)
+	if len(selected) == 0 {
+		return fmt.Errorf("no dependencies selected (target has %d direct deps across %v)", len(t.Deps), t.Ecosystems())
+	}
+
+	h, err := harness.ByName(resolved.backend)
+	if err != nil {
+		return err
+	}
+	models, err := resolveModels(h, resolved.models)
+	if err != nil {
+		return err
+	}
+
+	p := newPipeline(h, resolved.work, resolved.out, *run, resolveContainer(*container))
+	p.models = models
 	p.verify = *verify
 	return p.genAll(ctx, t, selected)
+}
+
+// resolveGenOptions applies built-in defaults, then config values, then only
+// the flags the user explicitly supplied. Its returned out path is rooted at
+// the target. Work from an auto-discovered config is ignored; an explicitly
+// selected config resolves work relative to the config directory.
+func resolveGenOptions(targetRoot, configPath string, explicitConfig bool, cfg hyrumconfig.File, cli genOptions, set map[string]bool) (genOptions, error) {
+	resolved := defaultGenOptions()
+	resolved.out = outRoot(targetRoot, resolved.out)
+
+	if cfg.Backend != nil {
+		resolved.backend = *cfg.Backend
+	}
+	if cfg.Out != nil {
+		expanded, err := hyrumconfig.ExpandUser(*cfg.Out)
+		if err != nil {
+			return genOptions{}, fmt.Errorf("out: %w", err)
+		}
+		resolved.out = outRoot(targetRoot, expanded)
+	}
+	if explicitConfig && cfg.Work != nil {
+		work, err := hyrumconfig.ResolvePath(configPath, *cfg.Work)
+		if err != nil {
+			return genOptions{}, fmt.Errorf("work: %w", err)
+		}
+		resolved.work = work
+	}
+	resolved.models = cfg.Models
+
+	if set["backend"] {
+		resolved.backend = cli.backend
+	}
+	if set["out"] {
+		expanded, err := hyrumconfig.ExpandUser(cli.out)
+		if err != nil {
+			return genOptions{}, fmt.Errorf("out: %w", err)
+		}
+		resolved.out = outRoot(targetRoot, expanded)
+	}
+	if set["work"] {
+		expanded, err := hyrumconfig.ExpandUser(cli.work)
+		if err != nil {
+			return genOptions{}, fmt.Errorf("work: %w", err)
+		}
+		resolved.work = expanded
+	}
+	trustedExternalOut := set["out"] || (explicitConfig && cfg.Out != nil)
+	if !trustedExternalOut && !pathWithinResolved(targetRoot, resolved.out) {
+		return genOptions{}, fmt.Errorf("out: automatic output must resolve inside target %q (use --out or explicit --config to trust an external output path)", targetRoot)
+	}
+	return resolved, nil
+}
+
+func pathWithinResolved(base, path string) bool {
+	resolvedBase, err := resolveExistingPath(base)
+	if err != nil {
+		return false
+	}
+	resolvedPath, err := resolveExistingPath(path)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedBase, resolvedPath)
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// resolveExistingPath resolves every existing symlink prefix of path, then
+// appends any not-yet-created suffix. Callers use it before creating output
+// paths so a symlink already present in an untrusted target cannot redirect a
+// nominally contained path elsewhere on the host.
+func resolveExistingPath(path string) (string, error) {
+	current, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	var missing []string
+	for {
+		resolved, evalErr := filepath.EvalSymlinks(current)
+		if evalErr == nil {
+			for i := len(missing) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, missing[i])
+			}
+			return filepath.Clean(resolved), nil
+		}
+		if !errors.Is(evalErr, os.ErrNotExist) {
+			return "", evalErr
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return "", evalErr
+		}
+		missing = append(missing, filepath.Base(current))
+		current = parent
+	}
+}
+
+func visitedFlags(fs *flag.FlagSet) map[string]bool {
+	set := make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		set[f.Name] = true
+	})
+	return set
+}
+
+func resolveModels(h harness.Harness, tiers map[string]string) (map[string]string, error) {
+	models := make(map[string]string, len(tiers))
+	for skill, tier := range tiers {
+		for _, candidate := range h.DefaultModels() {
+			if candidate.Tier == tier {
+				models[skill] = candidate.ID
+				break
+			}
+		}
+		if models[skill] == "" {
+			return nil, fmt.Errorf("models.%s: backend %s has no %q model tier", skill, harness.Name(h), tier)
+		}
+	}
+	return models, nil
 }
 
 // pipeline holds the shared configuration for running the stage → history →
@@ -84,6 +254,9 @@ type pipeline struct {
 	work    string
 	outRoot string
 	run     bool
+	// models maps skill names to backend-owned model IDs resolved from the
+	// portable mid/high/max tiers in hyrum.yaml.
+	models map[string]string
 	// containerImage non-empty means the runner is a ContainerRunner and each
 	// genOne call sets its TargetPath to the analysed target so /work/target
 	// is a read-only bind mount instead of a host symlink.
@@ -139,6 +312,14 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 		return err
 	}
 	ws := filepath.Join(p.work, targetDir, d.Ecosystem, d.Name)
+	if !pathWithinResolved(p.work, ws) {
+		return fmt.Errorf("dependency %q resolves outside work root %q", d.Name, p.work)
+	}
+	outRel := filepath.Join(d.Name, "from_"+targetDir)
+	outDir := filepath.Join(p.outRoot, outRel)
+	if !pathWithinResolved(p.outRoot, outDir) {
+		return fmt.Errorf("dependency %q resolves outside output root %q", d.Name, p.outRoot)
+	}
 	if err := prepareWorkspace(ws); err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
@@ -151,7 +332,10 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	}
 	if !p.run {
 		last := skillSteps[len(skillSteps)-1]
-		job := harness.Job{Workspace: ws, SrcDir: "target", SkillName: last.name, OutputFile: last.out}
+		job := harness.Job{
+			Workspace: ws, SrcDir: "target", SkillName: last.name,
+			OutputFile: last.out, Model: p.models[last.name],
+		}
 		fmt.Printf("staged %s: %s %v\n", d.Name, p.h.Binary(), p.h.Args(job))
 		return nil
 	}
@@ -161,49 +345,20 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if runner == nil {
 		runner = hyrum.ContainerRunner{Image: p.containerImage, TargetPath: t.Path}
 	}
-	var res *hyrum.RunResult
-	var totalCost float64
-	var recoveredSteps []string
-	for _, s := range skillSteps {
-		fmt.Fprintf(os.Stderr, "  [%s]\n", s.name)
-		r, err := runner.RunSkill(ctx, p.h, ws, s.name, s.out)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "  %s/%s: %v\n", d.Name, s.name, err)
-			if s.required {
-				return err
-			}
-			continue
-		}
-		if r.BackendError != "" {
-			fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", d.Name, s.name, r.BackendError)
-			recoveredSteps = append(recoveredSteps, s.name)
-		}
-		totalCost += r.CostUSD
-		res = r
-	}
-	if res == nil {
-		return fmt.Errorf("generate produced no output")
+	res, totalCost, recoveredSteps, err := p.runGenerateSkills(ctx, runner, ws, d.Name)
+	if err != nil {
+		return err
 	}
 	var gen hyrum.GenerateResult
 	if err := res.Decode(&gen); err != nil {
 		return fmt.Errorf("decode tests.json: %w", err)
 	}
 
-	outRel := filepath.Join(d.Name, "from_"+targetDir)
-	outDir := filepath.Join(p.outRoot, outRel)
 	written, err := hyrum.ReplaceFilesUnder(p.outRoot, outRel, gen.Files)
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
-	meta := map[string]any{
-		"purl":       d.PURL,
-		"ecosystem":  d.Ecosystem,
-		"baseline":   d.Version,
-		"target":     targetDir,
-		"session_id": res.SessionID,
-		"cost_usd":   totalCost,
-		"notes":      gen.Notes,
-	}
+	meta := generationMeta(targetDir, d, res, gen, totalCost)
 	if p.verify {
 		verify := p.runVerify(ctx, ws, d, latest, gen.Files)
 		meta["verify"] = verify
@@ -261,6 +416,45 @@ func addBackendRecoveries(meta map[string]any, steps []string) {
 	meta["recovered_steps"] = steps
 }
 
+func (p *pipeline) runGenerateSkills(ctx context.Context, runner hyrum.Runner, ws, depName string) (*hyrum.RunResult, float64, []string, error) {
+	var res *hyrum.RunResult
+	var totalCost float64
+	var recoveredSteps []string
+	for _, s := range skillSteps {
+		fmt.Fprintf(os.Stderr, "  [%s]\n", s.name)
+		r, err := runner.RunSkill(ctx, p.h, ws, s.name, s.out, hyrum.RunOptions{Model: p.models[s.name]})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  %s/%s: %v\n", depName, s.name, err)
+			if s.required {
+				return nil, totalCost, recoveredSteps, err
+			}
+			continue
+		}
+		if r.BackendError != "" {
+			fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", depName, s.name, r.BackendError)
+			recoveredSteps = append(recoveredSteps, s.name)
+		}
+		totalCost += r.CostUSD
+		res = r
+	}
+	if res == nil {
+		return nil, totalCost, recoveredSteps, fmt.Errorf("generate produced no output")
+	}
+	return res, totalCost, recoveredSteps, nil
+}
+
+func generationMeta(targetDir string, d hyrum.Dep, res *hyrum.RunResult, gen hyrum.GenerateResult, totalCost float64) map[string]any {
+	return map[string]any{
+		"purl":       d.PURL,
+		"ecosystem":  d.Ecosystem,
+		"baseline":   d.Version,
+		"target":     targetDir,
+		"session_id": res.SessionID,
+		"cost_usd":   totalCost,
+		"notes":      gen.Notes,
+	}
+}
+
 // runValidate stages the verify results and runs the hyrum-validate skill to
 // classify each latest-version failure and flag weak assertions. It returns
 // nil when there is nothing to validate (verify errored or ran no tests).
@@ -272,7 +466,7 @@ func (p *pipeline) runValidate(ctx context.Context, runner hyrum.Runner, ws stri
 		return nil, 0, "", err
 	}
 	fmt.Fprintf(os.Stderr, "  [hyrum-validate]\n")
-	r, err := runner.RunSkill(ctx, p.h, ws, "hyrum-validate", "verdict.json")
+	r, err := runner.RunSkill(ctx, p.h, ws, "hyrum-validate", "verdict.json", hyrum.RunOptions{Model: p.models["hyrum-validate"]})
 	if err != nil {
 		return nil, 0, "", err
 	}
@@ -561,6 +755,33 @@ func selectDeps(t *hyrum.Target, names stringList) []hyrum.Dep {
 		if d, ok := findDep(t, n); ok {
 			out = append(out, d)
 		}
+	}
+	return out
+}
+
+// selectGenDeps applies dependency configuration to copies of the analyzed
+// dependencies. Purl-specific values override name-specific values. Configured
+// skips affect default generation only; explicit --dep selections always win.
+func selectGenDeps(t *hyrum.Target, names stringList, overrides map[string]hyrumconfig.Dependency) []hyrum.Dep {
+	selected := selectDeps(t, names)
+	out := make([]hyrum.Dep, 0, len(selected))
+	for _, dep := range selected {
+		override := overrides[dep.Name]
+		if byPURL, ok := overrides[dep.PURL]; ok {
+			if byPURL.Baseline != nil {
+				override.Baseline = byPURL.Baseline
+			}
+			if byPURL.Skip != nil {
+				override.Skip = byPURL.Skip
+			}
+		}
+		if len(names) == 0 && override.Skip != nil && *override.Skip {
+			continue
+		}
+		if override.Baseline != nil {
+			dep.Version = *override.Baseline
+		}
+		out = append(out, dep)
 	}
 	return out
 }

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -211,6 +211,16 @@ func resolveExistingPath(path string) (string, error) {
 		if !errors.Is(evalErr, os.ErrNotExist) {
 			return "", evalErr
 		}
+		info, lstatErr := os.Lstat(current)
+		if lstatErr == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return "", fmt.Errorf("resolve symlink %q: %w", current, evalErr)
+			}
+			return "", evalErr
+		}
+		if !errors.Is(lstatErr, os.ErrNotExist) {
+			return "", lstatErr
+		}
 		parent := filepath.Dir(current)
 		if parent == current {
 			return "", evalErr

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -312,6 +312,13 @@ func TestPathWithinResolved(t *testing.T) {
 	if pathWithinResolved(root, filepath.Join(root, "link", "child")) {
 		t.Fatal("symlinked child should escape root")
 	}
+	danglingTarget := filepath.Join(t.TempDir(), "created-later")
+	if err := os.Symlink(danglingTarget, filepath.Join(root, "dangling")); err != nil {
+		t.Fatal(err)
+	}
+	if pathWithinResolved(root, filepath.Join(root, "dangling", "child")) {
+		t.Fatal("dangling symlink should fail closed")
+	}
 }
 
 func TestGenOneRejectsResolvedPathEscapes(t *testing.T) {

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,9 +11,28 @@ import (
 	"testing"
 
 	"github.com/alpha-omega-security/harness"
+	hyrumconfig "github.com/alpha-omega-security/hyrum/internal/config"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/git-pkgs/brief"
 )
+
+type runnerCall struct {
+	name  string
+	model string
+}
+
+type recordingRunner struct {
+	calls []runnerCall
+}
+
+func (r *recordingRunner) RunSkill(_ context.Context, _ harness.Harness, _, name, _ string, opts hyrum.RunOptions) (*hyrum.RunResult, error) {
+	r.calls = append(r.calls, runnerCall{name: name, model: opts.Model})
+	output := json.RawMessage(`{"files":[]}`)
+	if name == "hyrum-validate" {
+		output = json.RawMessage(`{"verdicts":[]}`)
+	}
+	return &hyrum.RunResult{Output: output}, nil
+}
 
 func TestAnyRan(t *testing.T) {
 	if anyRan(nil) {
@@ -129,7 +149,7 @@ type recoveredRunner struct {
 	output json.RawMessage
 }
 
-func (r recoveredRunner) RunSkill(context.Context, harness.Harness, string, string, string) (*hyrum.RunResult, error) {
+func (r recoveredRunner) RunSkill(context.Context, harness.Harness, string, string, string, hyrum.RunOptions) (*hyrum.RunResult, error) {
 	output := r.output
 	if output == nil {
 		output = json.RawMessage(`{"verdicts":[{"test":"t","status":"weak","action":"strengthen","reasoning":"r"}]}`)
@@ -174,5 +194,311 @@ func TestRunValidateDecodeFailureDoesNotReturnRecovery(t *testing.T) {
 	}
 	if recovery != "" {
 		t.Fatalf("discarded output reported as recovered: %q", recovery)
+	}
+}
+
+func TestResolveGenOptionsPrecedence(t *testing.T) {
+	configDir := t.TempDir()
+	configPath := filepath.Join(configDir, "hyrum.yaml")
+	target := t.TempDir()
+	backend, configOut, configWork := "codex", "configured/out", "configured/work"
+	cfg := hyrumconfig.File{Backend: &backend, Out: &configOut, Work: &configWork}
+
+	t.Run("discovered config cannot set work", func(t *testing.T) {
+		got, err := resolveGenOptions(target, configPath, false, cfg, defaultGenOptions(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.backend != "codex" {
+			t.Errorf("backend = %q", got.backend)
+		}
+		if got.out != filepath.Join(target, configOut) {
+			t.Errorf("out = %q", got.out)
+		}
+		if got.work != defaultGenOptions().work {
+			t.Errorf("work = %q", got.work)
+		}
+	})
+
+	t.Run("explicit config can set work", func(t *testing.T) {
+		got, err := resolveGenOptions(target, configPath, true, cfg, defaultGenOptions(), nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.work != filepath.Join(configDir, configWork) {
+			t.Errorf("work = %q", got.work)
+		}
+	})
+
+	t.Run("explicit flags over config", func(t *testing.T) {
+		cli := defaultGenOptions()
+		cli.backend = "claude" // Deliberately equal to the built-in default.
+		cli.out = "cli/out"
+		cli.work = "cli/work"
+		set := map[string]bool{"backend": true, "out": true, "work": true}
+		got, err := resolveGenOptions(target, configPath, false, cfg, cli, set)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.backend != "claude" || got.out != filepath.Join(target, "cli/out") || got.work != "cli/work" {
+			t.Fatalf("resolved = %+v", got)
+		}
+	})
+}
+
+func TestResolveGenOptionsExpandsConfiguredOutFromTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	target := t.TempDir()
+	configured := "~/hyrum-output"
+	cfg := hyrumconfig.File{Out: &configured}
+	got, err := resolveGenOptions(target, filepath.Join(t.TempDir(), "hyrum.yaml"), true, cfg, defaultGenOptions(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.out != filepath.Join(home, "hyrum-output") {
+		t.Fatalf("out = %q", got.out)
+	}
+}
+
+func TestResolveGenOptionsConfinesDiscoveredOutToTarget(t *testing.T) {
+	target := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	cfg := hyrumconfig.File{Out: &outside}
+	_, err := resolveGenOptions(target, filepath.Join(target, "hyrum.yaml"), false, cfg, defaultGenOptions(), nil)
+	if err == nil || !strings.Contains(err.Error(), "automatic output") {
+		t.Fatalf("error = %v, want discovered-config confinement error", err)
+	}
+}
+
+func TestResolveGenOptionsRejectsDiscoveredOutThroughSymlink(t *testing.T) {
+	target := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(target, "redirect")); err != nil {
+		t.Fatal(err)
+	}
+	configured := "redirect/generated"
+	cfg := hyrumconfig.File{Out: &configured}
+	_, err := resolveGenOptions(target, filepath.Join(target, "hyrum.yaml"), false, cfg, defaultGenOptions(), nil)
+	if err == nil || !strings.Contains(err.Error(), "automatic output") {
+		t.Fatalf("error = %v, want symlink confinement error", err)
+	}
+}
+
+func TestResolveGenOptionsRejectsDefaultOutThroughSymlink(t *testing.T) {
+	target := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(target, "tests")); err != nil {
+		t.Fatal(err)
+	}
+	_, err := resolveGenOptions(target, "", false, hyrumconfig.File{}, defaultGenOptions(), nil)
+	if err == nil || !strings.Contains(err.Error(), "automatic output") {
+		t.Fatalf("error = %v, want default-output confinement error", err)
+	}
+}
+
+func TestPathWithinResolved(t *testing.T) {
+	root := t.TempDir()
+	if !pathWithinResolved(root, filepath.Join(root, "not", "created")) {
+		t.Fatal("missing child should remain inside root")
+	}
+	if pathWithinResolved(root, filepath.Join(root, "..", "outside")) {
+		t.Fatal("parent traversal should escape root")
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(root, "link")); err != nil {
+		t.Fatal(err)
+	}
+	if pathWithinResolved(root, filepath.Join(root, "link", "child")) {
+		t.Fatal("symlinked child should escape root")
+	}
+}
+
+func TestGenOneRejectsResolvedPathEscapes(t *testing.T) {
+	target := &hyrum.Target{Path: t.TempDir(), Report: &brief.Report{}}
+	targetDir := filepath.Base(target.Path)
+	dep := hyrum.Dep{Name: "ws", Ecosystem: "npm"}
+
+	t.Run("work root", func(t *testing.T) {
+		p := &pipeline{work: t.TempDir(), outRoot: t.TempDir()}
+		if err := os.Symlink(t.TempDir(), filepath.Join(p.work, targetDir)); err != nil {
+			t.Fatal(err)
+		}
+		err := p.genOne(context.Background(), target, nil, dep)
+		if err == nil || !strings.Contains(err.Error(), "outside work root") {
+			t.Fatalf("error = %v, want work-root confinement error", err)
+		}
+	})
+
+	t.Run("output root", func(t *testing.T) {
+		p := &pipeline{work: t.TempDir(), outRoot: t.TempDir()}
+		if err := os.Symlink(t.TempDir(), filepath.Join(p.outRoot, dep.Name)); err != nil {
+			t.Fatal(err)
+		}
+		err := p.genOne(context.Background(), target, nil, dep)
+		if err == nil || !strings.Contains(err.Error(), "outside output root") {
+			t.Fatalf("error = %v, want output-root confinement error", err)
+		}
+	})
+}
+
+func TestResolveGenOptionsExplicitOutOverridesUnsafeDiscoveredOut(t *testing.T) {
+	target := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside")
+	cfg := hyrumconfig.File{Out: &outside}
+	cli := defaultGenOptions()
+	cli.out = "safe-output"
+	got, err := resolveGenOptions(target, filepath.Join(target, "hyrum.yaml"), false, cfg, cli, map[string]bool{"out": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.out != filepath.Join(target, "safe-output") {
+		t.Fatalf("out = %q", got.out)
+	}
+}
+
+func TestCmdGenRejectsFlagsAfterTarget(t *testing.T) {
+	target := t.TempDir()
+	err := cmdGen(context.Background(), []string{target, "--config", filepath.Join(t.TempDir(), "missing.yaml")})
+	if err == nil || !strings.Contains(err.Error(), "unexpected arguments after <path>") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCmdGenConfigFileBehavior(t *testing.T) {
+	target := t.TempDir()
+
+	t.Run("missing explicit", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "missing.yaml")
+		err := cmdGen(context.Background(), []string{"--config", missing, target})
+		if err == nil || !strings.Contains(err.Error(), "read config") || !strings.Contains(err.Error(), missing) {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("missing automatic is optional", func(t *testing.T) {
+		err := cmdGen(context.Background(), []string{target})
+		if err == nil || !strings.Contains(err.Error(), "no dependencies selected") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+}
+
+func TestVisitedFlagsRecordsExplicitDefaults(t *testing.T) {
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.String("backend", "claude", "")
+	if err := fs.Parse([]string{"--backend", "claude"}); err != nil {
+		t.Fatal(err)
+	}
+	if !visitedFlags(fs)["backend"] {
+		t.Fatal("explicit default-valued flag was not recorded")
+	}
+}
+
+func TestSelectGenDepsAppliesOverridesWithoutMutatingTarget(t *testing.T) {
+	target := &hyrum.Target{Deps: []hyrum.Dep{
+		{Name: "ws", PURL: "pkg:npm/ws", Version: "^7.4.2", Direct: true},
+		{Name: "lodash", PURL: "pkg:npm/lodash", Version: "4.17.20", Direct: true},
+	}}
+	baseline := "8.17.1"
+	skip := true
+	overrides := map[string]hyrumconfig.Dependency{
+		"ws":             {Baseline: &baseline},
+		"pkg:npm/lodash": {Skip: &skip},
+	}
+
+	got := selectGenDeps(target, nil, overrides)
+	if len(got) != 1 || got[0].Name != "ws" || got[0].Version != baseline {
+		t.Fatalf("default selection = %+v", got)
+	}
+	if target.Deps[0].Version != "^7.4.2" {
+		t.Fatalf("target dependency mutated: %+v", target.Deps[0])
+	}
+
+	got = selectGenDeps(target, stringList{"pkg:npm/lodash"}, overrides)
+	if len(got) != 1 || got[0].Name != "lodash" {
+		t.Fatalf("explicit --dep should override skip: %+v", got)
+	}
+}
+
+func TestSelectGenDepsOverrideByPURL(t *testing.T) {
+	target := &hyrum.Target{Deps: []hyrum.Dep{{
+		Name: "ws", PURL: "pkg:npm/ws", Version: "7.4.2", Direct: true,
+	}}}
+	baseline := "8.0.0"
+	got := selectGenDeps(target, nil, map[string]hyrumconfig.Dependency{
+		"pkg:npm/ws": {Baseline: &baseline},
+	})
+	if len(got) != 1 || got[0].Version != baseline {
+		t.Fatalf("selection = %+v", got)
+	}
+}
+
+func TestResolveModelsUsesHarnessTier(t *testing.T) {
+	h := harness.CodexHarness{}
+	got, err := resolveModels(h, map[string]string{
+		"hyrum-usage":    "mid",
+		"hyrum-generate": "high",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{}
+	for _, model := range h.DefaultModels() {
+		want[model.Tier] = model.ID
+	}
+	if want["mid"] == "" || want["high"] == "" {
+		t.Fatalf("Codex defaults lack required tiers: %v", h.DefaultModels())
+	}
+	if got["hyrum-usage"] != want["mid"] || got["hyrum-generate"] != want["high"] {
+		t.Fatalf("models = %v, want mid=%q high=%q", got, want["mid"], want["high"])
+	}
+}
+
+func TestPipelinePropagatesModelsToEverySkill(t *testing.T) {
+	models := map[string]string{
+		"hyrum-usage":    "usage-model",
+		"hyrum-history":  "history-model",
+		"hyrum-generate": "generate-model",
+		"hyrum-validate": "validate-model",
+	}
+	p := &pipeline{models: models}
+	runner := &recordingRunner{}
+
+	if _, _, _, err := p.runGenerateSkills(context.Background(), runner, t.TempDir(), "ws"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, _, err := p.runValidate(context.Background(), runner, t.TempDir(), []hyrum.VerifyResult{{Pass: 1}}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != 4 {
+		t.Fatalf("calls = %+v", runner.calls)
+	}
+	for _, call := range runner.calls {
+		if call.model != models[call.name] {
+			t.Errorf("%s model = %q, want %q", call.name, call.model, models[call.name])
+		}
+	}
+}
+
+func TestConfiguredBaselineReachesMetadata(t *testing.T) {
+	target := &hyrum.Target{
+		Path:   t.TempDir(),
+		Report: &brief.Report{},
+		Deps:   []hyrum.Dep{{Name: "ws", PURL: "pkg:npm/ws", Version: "7.4.2", Ecosystem: "npm", Direct: true}},
+	}
+	baseline := "8.17.1"
+	selected := selectGenDeps(target, nil, map[string]hyrumconfig.Dependency{
+		"ws": {Baseline: &baseline},
+	})
+	if len(selected) != 1 {
+		t.Fatalf("selected = %+v", selected)
+	}
+	meta := generationMeta("target", selected[0], &hyrum.RunResult{}, hyrum.GenerateResult{}, 0)
+	if got := meta["baseline"]; got != baseline {
+		t.Fatalf("baseline = %v, want %q", got, baseline)
+	}
+	if target.Deps[0].Version != "7.4.2" {
+		t.Fatalf("target dependency mutated: %+v", target.Deps[0])
 	}
 }

--- a/cmd/hyrum/main.go
+++ b/cmd/hyrum/main.go
@@ -67,7 +67,7 @@ const usageText = `hyrum: generate and run Hyrum's tests
 
 Usage:
   hyrum surface [--dep name] [--json] [path]
-  hyrum gen     [--dep name] [--out dir] [--backend name] [--run] [path]
+  hyrum gen     [--config file] [--dep name] [--out dir] [--work dir] [--backend name] [--run] [path]
   hyrum check   --dep name[@version] [--tests dir] [path]
   hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N]
 

--- a/cmd/hyrum/main_test.go
+++ b/cmd/hyrum/main_test.go
@@ -8,7 +8,7 @@ import (
 func TestUsageShowsAcceptedArgumentOrder(t *testing.T) {
 	for _, want := range []string{
 		"hyrum surface [--dep name] [--json] [path]",
-		"hyrum gen     [--dep name] [--out dir] [--backend name] [--run] [path]",
+		"hyrum gen     [--config file] [--dep name] [--out dir] [--work dir] [--backend name] [--run] [path]",
 		"hyrum check   --dep name[@version] [--tests dir] [path]",
 		"hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N]",
 	} {

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/git-pkgs/registries v0.6.4
 	github.com/git-pkgs/vers v0.3.0
 	github.com/git-pkgs/vulns v0.2.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -39,5 +40,4 @@ require (
 	github.com/package-url/packageurl-go v0.1.6 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/rogpeppe/go-internal v1.16.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/hyrum.sample.yaml
+++ b/hyrum.sample.yaml
@@ -1,26 +1,34 @@
-# hyrum config. Copy to hyrum.yaml or point at it with --config.
-# All keys optional; command-line flags win.
+# Hyrum configuration. Copy this file to <target>/hyrum.yaml for automatic
+# discovery, or pass it explicitly with `hyrum gen --config <path> ...`.
+# All keys are optional. Explicit command-line flags win over config values,
+# which win over built-in defaults. Unknown keys and incorrect types are
+# errors.
 
 # Harness backend for LLM-driven skills.
 # backend: claude          # claude | codex | copilot | opencode
 
-# Per-skill model tier. Keys match skills/<name>/.
+# Per-skill model tier. The selected backend maps mid/high/max to its own
+# models. Keys match the model-driven skills under skills/.
 # models:
 #   hyrum-usage:    mid
 #   hyrum-history:  mid
 #   hyrum-generate: high
 #   hyrum-validate: mid
 
-# Where generated tests are written, relative to the target repo.
+# Where generated tests are written. Relative paths use the target repository;
+# automatic target configs must keep output inside that repository. Explicit
+# --config files may also use absolute paths and paths beginning with ~/.
 # out: tests/hyrum
 
-# Working directory for dep clones and skill workspaces.
+# Working directory for dependency clones and skill workspaces. This setting is
+# ignored when the config is auto-discovered; pass --config explicitly to trust
+# it. Relative paths use the directory containing that explicit config file.
 # work: ~/.cache/hyrum
 
 # Per-dependency overrides. Keys are package names or purls.
 # deps:
 #   ws:
-#     baseline: 8.17.1     # version to validate generated tests against
+#     baseline: "8.17.1"   # staged/recorded baseline; target files are unchanged
 #     skip: false
 #   pkg:npm/lodash:
-#     skip: true           # too large / not worth generating for
+#     skip: true           # omitted by default; explicit --dep still includes it

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,301 @@
+// Package config parses and validates hyrum.yaml independently from command
+// execution so the same configuration contract can be reused by other
+// subcommands as they gain configuration support.
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	Filename      = "hyrum.yaml"
+	yamlStringTag = "!!str"
+	yamlBoolTag   = "!!bool"
+)
+
+// File is the typed representation of hyrum.yaml. Pointer scalar fields
+// preserve the distinction between an omitted setting and an explicit value.
+type File struct {
+	Backend *string               `yaml:"backend,omitempty"`
+	Models  map[string]string     `yaml:"models,omitempty"`
+	Out     *string               `yaml:"out,omitempty"`
+	Work    *string               `yaml:"work,omitempty"`
+	Deps    map[string]Dependency `yaml:"deps,omitempty"`
+}
+
+// Dependency contains generation overrides for one dependency, keyed by its
+// manifest name or full purl in File.Deps.
+type Dependency struct {
+	Baseline *string `yaml:"baseline,omitempty"`
+	Skip     *bool   `yaml:"skip,omitempty"`
+}
+
+var modelSkills = map[string]bool{
+	"hyrum-usage":    true,
+	"hyrum-history":  true,
+	"hyrum-generate": true,
+	"hyrum-validate": true,
+}
+
+var modelTiers = map[string]bool{
+	"mid":  true,
+	"high": true,
+	"max":  true,
+}
+
+// Load reads an explicitly requested config, or discovers hyrum.yaml exactly
+// at targetRoot. An absent discovered file is optional; every error for an
+// explicit file is returned. source is the absolute path of the loaded file.
+func Load(targetRoot, explicit string) (cfg File, source string, err error) {
+	var path string
+	if explicit != "" {
+		path, err = ExpandUser(explicit)
+		if err != nil {
+			return File{}, "", fmt.Errorf("config path: %w", err)
+		}
+		path, err = filepath.Abs(path)
+		if err != nil {
+			return File{}, "", fmt.Errorf("config path: %w", err)
+		}
+	} else {
+		root, absErr := filepath.Abs(targetRoot)
+		if absErr != nil {
+			return File{}, "", fmt.Errorf("target path: %w", absErr)
+		}
+		path = filepath.Join(root, Filename)
+	}
+
+	b, readErr := os.ReadFile(path)
+	if readErr != nil {
+		if explicit == "" && errors.Is(readErr, os.ErrNotExist) {
+			return File{}, "", nil
+		}
+		return File{}, "", fmt.Errorf("read config %q: %w", path, readErr)
+	}
+	cfg, err = Parse(b)
+	if err != nil {
+		return File{}, "", fmt.Errorf("parse config %q: %w", path, err)
+	}
+	return cfg, filepath.Clean(path), nil
+}
+
+// Parse strictly decodes one YAML document. Unknown fields, nulls, type
+// mismatches, unsupported model settings, and empty scalar values fail closed.
+func Parse(data []byte) (File, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return File{}, err
+	}
+	if err := rejectNulls(&root); err != nil {
+		return File{}, err
+	}
+	if err := validateNodeTypes(&root); err != nil {
+		return File{}, err
+	}
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var cfg File
+	if err := dec.Decode(&cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return File{}, nil
+		}
+		return File{}, err
+	}
+	var extra any
+	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return File{}, fmt.Errorf("multiple YAML documents are not supported")
+		}
+		return File{}, err
+	}
+	if err := cfg.validate(); err != nil {
+		return File{}, err
+	}
+	return cfg, nil
+}
+
+func (cfg File) validate() error {
+	for name, value := range map[string]*string{
+		"backend": cfg.Backend,
+		"out":     cfg.Out,
+		"work":    cfg.Work,
+	} {
+		if value != nil && strings.TrimSpace(*value) == "" {
+			return fmt.Errorf("%s must not be empty", name)
+		}
+	}
+	for skill, tier := range cfg.Models {
+		if !modelSkills[skill] {
+			return fmt.Errorf("models.%s is unsupported", skill)
+		}
+		if !modelTiers[tier] {
+			return fmt.Errorf("models.%s has unsupported tier %q (want mid, high, or max)", skill, tier)
+		}
+	}
+	for key, dep := range cfg.Deps {
+		if strings.TrimSpace(key) == "" {
+			return fmt.Errorf("deps contains an empty dependency key")
+		}
+		if dep.Baseline != nil && strings.TrimSpace(*dep.Baseline) == "" {
+			return fmt.Errorf("deps.%s.baseline must not be empty", key)
+		}
+	}
+	return nil
+}
+
+func rejectNulls(node *yaml.Node) error {
+	if node == nil {
+		return nil
+	}
+	if node.Tag == "!!null" {
+		return fmt.Errorf("null values are not supported (line %d)", node.Line)
+	}
+	for _, child := range node.Content {
+		if err := rejectNulls(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNodeTypes(root *yaml.Node) error {
+	if root == nil || len(root.Content) == 0 {
+		return nil
+	}
+	node := root.Content[0]
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("configuration must be a mapping (line %d)", node.Line)
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Tag != yamlStringTag {
+			return fmt.Errorf("configuration keys must be strings (line %d)", key.Line)
+		}
+		switch key.Value {
+		case "backend", "out", "work":
+			if err := requireTag(key.Value, value, yamlStringTag); err != nil {
+				return err
+			}
+		case "models":
+			if err := validateStringMap("models", value); err != nil {
+				return err
+			}
+		case "deps":
+			if err := validateDependencies(value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateStringMap(path string, node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s must be a mapping (line %d)", path, node.Line)
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Tag != yamlStringTag {
+			return fmt.Errorf("%s keys must be strings (line %d)", path, key.Line)
+		}
+		if err := requireTag(path+"."+key.Value, value, yamlStringTag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDependencies(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("deps must be a mapping (line %d)", node.Line)
+	}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+		if key.Tag != yamlStringTag {
+			return fmt.Errorf("deps keys must be strings (line %d)", key.Line)
+		}
+		if value.Kind != yaml.MappingNode {
+			return fmt.Errorf("deps.%s must be a mapping (line %d)", key.Value, value.Line)
+		}
+		for j := 0; j < len(value.Content); j += 2 {
+			field, fieldValue := value.Content[j], value.Content[j+1]
+			if field.Tag != yamlStringTag {
+				return fmt.Errorf("deps.%s keys must be strings (line %d)", key.Value, field.Line)
+			}
+			switch field.Value {
+			case "baseline":
+				if err := requireTag("deps."+key.Value+".baseline", fieldValue, yamlStringTag); err != nil {
+					return err
+				}
+			case "skip":
+				if err := requireTag("deps."+key.Value+".skip", fieldValue, yamlBoolTag); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func requireTag(path string, node *yaml.Node, tag string) error {
+	if node.Kind == yaml.AliasNode {
+		return fmt.Errorf("%s aliases are not supported (line %d)", path, node.Line)
+	}
+	if node.Tag != tag {
+		switch {
+		case tag == yamlStringTag && strings.HasSuffix(path, ".baseline"):
+			return fmt.Errorf("%s must be a quoted string (got %s at line %d)", path, node.Tag, node.Line)
+		case tag == yamlStringTag:
+			return fmt.Errorf("%s must be a string (got %s at line %d)", path, node.Tag, node.Line)
+		case tag == yamlBoolTag:
+			return fmt.Errorf("%s must be true or false (got %s at line %d)", path, node.Tag, node.Line)
+		default:
+			return fmt.Errorf("%s has the wrong type %s (line %d)", path, node.Tag, node.Line)
+		}
+	}
+	return nil
+}
+
+// ResolvePath expands a configured path and resolves relative values from the
+// directory containing the loaded config file.
+func ResolvePath(source, value string) (string, error) {
+	expanded, err := ExpandUser(value)
+	if err != nil {
+		return "", err
+	}
+	if filepath.IsAbs(expanded) {
+		return filepath.Clean(expanded), nil
+	}
+	if source == "" {
+		return "", fmt.Errorf("cannot resolve relative configured path %q without a config file", value)
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(source), expanded)), nil
+}
+
+// ExpandUser expands a leading ~ or ~/ using the current user's home. Other
+// users' home directories (~name) are intentionally not inferred.
+func ExpandUser(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~"+string(filepath.Separator)) {
+		if strings.HasPrefix(path, "~") {
+			return "", fmt.Errorf("unsupported home path %q (only ~ and ~/ are expanded)", path)
+		}
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	return filepath.Join(home, strings.TrimPrefix(path, "~"+string(filepath.Separator))), nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadExplicitConfig(t *testing.T) {
+	target := t.TempDir()
+	path := filepath.Join(t.TempDir(), "custom.yaml")
+	writeTestConfig(t, path, `
+backend: codex
+out: generated/hyrum
+work: workspaces
+models:
+  hyrum-generate: high
+deps:
+  ws:
+    baseline: 8.17.1
+    skip: false
+`)
+
+	cfg, source, err := Load(target, path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if source != path {
+		t.Fatalf("source = %q, want %q", source, path)
+	}
+	if cfg.Backend == nil || *cfg.Backend != "codex" {
+		t.Fatalf("backend = %v", cfg.Backend)
+	}
+	if got := cfg.Models["hyrum-generate"]; got != "high" {
+		t.Fatalf("generate model = %q", got)
+	}
+	dep := cfg.Deps["ws"]
+	if dep.Baseline == nil || *dep.Baseline != "8.17.1" {
+		t.Fatalf("baseline = %v", dep.Baseline)
+	}
+	if dep.Skip == nil || *dep.Skip {
+		t.Fatalf("skip = %v", dep.Skip)
+	}
+}
+
+func TestLoadDiscoversTargetRootConfigWithoutWalkingParents(t *testing.T) {
+	parent := t.TempDir()
+	target := filepath.Join(parent, "repo")
+	if err := os.Mkdir(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestConfig(t, filepath.Join(parent, Filename), "backend: codex\n")
+
+	cfg, source, err := Load(target, "")
+	if err != nil {
+		t.Fatalf("missing optional config: %v", err)
+	}
+	if source != "" || cfg.Backend != nil {
+		t.Fatalf("walked above target root: source=%q backend=%v", source, cfg.Backend)
+	}
+
+	wantSource := filepath.Join(target, Filename)
+	writeTestConfig(t, wantSource, "backend: copilot\n")
+	cfg, source, err = Load(target, "")
+	if err != nil {
+		t.Fatalf("discovered config: %v", err)
+	}
+	if source != wantSource || cfg.Backend == nil || *cfg.Backend != "copilot" {
+		t.Fatalf("source=%q backend=%v", source, cfg.Backend)
+	}
+}
+
+func TestLoadMissingExplicitConfigFails(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing.yaml")
+	_, _, err := Load(t.TempDir(), missing)
+	if err == nil || !strings.Contains(err.Error(), missing) {
+		t.Fatalf("error = %v, want explicit path", err)
+	}
+}
+
+func TestLoadUnreadableExplicitConfigFails(t *testing.T) {
+	path := t.TempDir() // Reading a directory as a config fails on every platform.
+	_, _, err := Load(t.TempDir(), path)
+	if err == nil || !strings.Contains(err.Error(), path) {
+		t.Fatalf("error = %v, want explicit path", err)
+	}
+}
+
+func TestParseRejectsMalformedUnknownAndIncorrectTypes(t *testing.T) {
+	tests := map[string]string{
+		"malformed":       "backend: [\n",
+		"unknown top key": "backed: codex\n",
+		"unknown dep key": "deps:\n  ws:\n    basline: 1.0\n",
+		"backend type":    "backend: true\n",
+		"skip type":       "deps:\n  ws:\n    skip: yes-please\n",
+		"null":            "work: null\n",
+		"second document": "backend: codex\n---\nbackend: claude\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(body)); err == nil {
+				t.Fatal("Parse succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestParseTypeErrorExplainsQuotedBaseline(t *testing.T) {
+	_, err := Parse([]byte("deps:\n  ws:\n    baseline: 8.17\n"))
+	if err == nil {
+		t.Fatal("Parse succeeded, want error")
+	}
+	for _, want := range []string{"must be a quoted string", "!!float", "line 3"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want %q", err, want)
+		}
+	}
+}
+
+func TestParseRejectsDuplicateAliasAndMergeKeys(t *testing.T) {
+	tests := map[string]string{
+		"duplicate": "backend: codex\nbackend: claude\n",
+		"alias":     "out: &outside /tmp/out\nwork: *outside\n",
+		"merge":     "defaults: &defaults\n  skip: true\ndeps:\n  ws:\n    <<: *defaults\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(body)); err == nil {
+				t.Fatal("Parse succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestParseRejectsUnsupportedModelSettings(t *testing.T) {
+	tests := map[string]string{
+		"unknown skill": "models:\n  hyrum-magic: high\n",
+		"unknown tier":  "models:\n  hyrum-generate: enormous\n",
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Parse([]byte(body)); err == nil {
+				t.Fatal("Parse succeeded, want error")
+			}
+		})
+	}
+}
+
+func TestConfiguredPathResolution(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	configPath := filepath.Join(t.TempDir(), "config", Filename)
+
+	tests := []struct {
+		name, value, want string
+	}{
+		{"tilde", "~/.cache/hyrum", filepath.Join(home, ".cache", "hyrum")},
+		{"relative", "work/hyrum", filepath.Join(filepath.Dir(configPath), "work", "hyrum")},
+		{"absolute", filepath.Join(t.TempDir(), "work"), ""},
+	}
+	tests[2].want = tests[2].value
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := ResolvePath(configPath, test.value)
+			if err != nil {
+				t.Fatalf("ResolvePath: %v", err)
+			}
+			if got != test.want {
+				t.Fatalf("got %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func writeTestConfig(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/hyrum/container.go
+++ b/internal/hyrum/container.go
@@ -21,15 +21,15 @@ const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:lates
 // Runner runs one skill and returns its parsed output. HostRunner and
 // ContainerRunner both satisfy it so the pipeline can switch on a flag.
 type Runner interface {
-	RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string) (*RunResult, error)
+	RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions) (*RunResult, error)
 }
 
 // HostRunner runs the backend directly on the host via harness.Run. It is the
 // default and requires the backend binary on PATH.
 type HostRunner struct{}
 
-func (HostRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, out string) (*RunResult, error) {
-	return RunSkill(ctx, h, ws, name, out)
+func (HostRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, out string, opts RunOptions) (*RunResult, error) {
+	return RunSkillWithOptions(ctx, h, ws, name, out, opts)
 }
 
 // ContainerRunner runs the backend inside an ephemeral container with a fresh
@@ -50,7 +50,7 @@ type ContainerRunner struct {
 	Emit func(harness.Event)
 }
 
-func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string) (*RunResult, error) {
+func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions) (*RunResult, error) {
 	skillDir, err := skills.Stage(h, ws, name)
 	if err != nil {
 		return nil, fmt.Errorf("stage skill: %w", err)
@@ -86,6 +86,7 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 		SkillName:    name,
 		OutputFile:   outputFile,
 		SystemPrompt: headlessSystemPrompt,
+		Model:        opts.Model,
 	}
 
 	runtime := r.Runtime
@@ -108,9 +109,11 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 	cmd.Stdout = pw
 	cmd.Stderr = io.MultiWriter(pw, &stderr)
 
-	model := ""
-	if defs := h.DefaultModels(); len(defs) > 0 {
-		model = defs[0].ID
+	model := opts.Model
+	if model == "" {
+		if defs := h.DefaultModels(); len(defs) > 0 {
+			model = defs[0].ID
+		}
 	}
 	emit := r.Emit
 	if emit == nil {

--- a/internal/hyrum/container_test.go
+++ b/internal/hyrum/container_test.go
@@ -70,7 +70,7 @@ exit 1
 	}
 
 	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
-	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	if err != nil {
 		t.Fatalf("fresh valid output should survive container failure: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestContainerRunnerBackendFailureDoesNotReuseStaleOutput(t *testing.T) {
 	}
 
 	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
-	if _, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json"); err == nil {
+	if _, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{}); err == nil {
 		t.Fatal("want error rather than stale container output")
 	}
 	if _, err := os.Stat(outputPath); !os.IsNotExist(err) {
@@ -123,7 +123,7 @@ exit 1
 	}
 
 	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
-	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	if err != nil {
 		t.Fatalf("fresh valid output should survive container failure: %v", err)
 	}
@@ -151,9 +151,22 @@ exit 1
 	}
 
 	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
-	_, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json")
+	_, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	var accountErr *harness.AccountError
 	if !errors.As(err, &accountErr) {
 		t.Fatalf("want typed account error, got %v", err)
+	}
+}
+
+func TestContainerRunnerPassesConfiguredModel(t *testing.T) {
+	ws := t.TempDir()
+	h := &recordingHarness{shHarness: shHarness{payload: `{"files":[]}`}}
+	r := ContainerRunner{Runtime: filepath.Join(t.TempDir(), "missing-runtime")}
+	_, err := r.RunSkill(context.Background(), h, ws, "hyrum-generate", "tests.json", RunOptions{Model: "claude-opus-4-6"})
+	if err == nil {
+		t.Fatal("RunSkill succeeded with missing runtime")
+	}
+	if h.model != "claude-opus-4-6" {
+		t.Fatalf("model = %q", h.model)
 	}
 }

--- a/internal/hyrum/run.go
+++ b/internal/hyrum/run.go
@@ -58,6 +58,11 @@ type RunResult struct {
 
 const recoveredBackendError = "backend exited non-zero after writing fresh output"
 
+// RunOptions contains backend-neutral per-invocation settings.
+type RunOptions struct {
+	Model string
+}
+
 // Decode unmarshals the skill's output file into v.
 func (r *RunResult) Decode(v any) error {
 	return json.Unmarshal(r.Output, v)
@@ -68,11 +73,20 @@ func (r *RunResult) Decode(v any) error {
 // simple progress log; a caller wanting structured events can pass its own
 // emit via RunSkillWithEmit.
 func RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string) (*RunResult, error) {
-	return RunSkillWithEmit(ctx, h, ws, name, outputFile, defaultEmit)
+	return RunSkillWithOptions(ctx, h, ws, name, outputFile, RunOptions{})
+}
+
+// RunSkillWithOptions is RunSkill with backend-neutral invocation settings.
+func RunSkillWithOptions(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions) (*RunResult, error) {
+	return runSkill(ctx, h, ws, name, outputFile, opts, defaultEmit)
 }
 
 // RunSkillWithEmit is RunSkill with a caller-provided event sink.
 func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFile string, emit func(harness.Event)) (*RunResult, error) {
+	return runSkill(ctx, h, ws, name, outputFile, RunOptions{}, emit)
+}
+
+func runSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions, emit func(harness.Event)) (*RunResult, error) {
 	skillDir, err := skills.Stage(h, ws, name)
 	if err != nil {
 		return nil, fmt.Errorf("stage skill: %w", err)
@@ -90,6 +104,7 @@ func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFi
 		SkillName:    name,
 		OutputFile:   outputFile,
 		SystemPrompt: headlessSystemPrompt,
+		Model:        opts.Model,
 	}
 	outputPath, err := prepareOutput(ws, outputFile)
 	if err != nil {
@@ -99,9 +114,11 @@ func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFi
 	// Backends that do not report a price (codex) still report token usage;
 	// fall back to the list-price estimate for the backend's default model so
 	// meta.json carries something better than zero.
-	model := ""
-	if defs := h.DefaultModels(); len(defs) > 0 {
-		model = defs[0].ID
+	model := opts.Model
+	if model == "" {
+		if defs := h.DefaultModels(); len(defs) > 0 {
+			model = defs[0].ID
+		}
 	}
 
 	res := &RunResult{}

--- a/internal/hyrum/run_test.go
+++ b/internal/hyrum/run_test.go
@@ -26,6 +26,16 @@ type shHarness struct {
 	block   bool
 }
 
+type recordingHarness struct {
+	shHarness
+	model string
+}
+
+func (h *recordingHarness) Args(j harness.Job) []string {
+	h.model = j.Model
+	return h.shHarness.Args(j)
+}
+
 func (h shHarness) Binary() string { return "/bin/sh" }
 
 func (h shHarness) Args(j harness.Job) []string {
@@ -87,6 +97,17 @@ func TestRunSkillWritesFiles(t *testing.T) {
 	b, _ := os.ReadFile(written[0])
 	if string(b) != "// generated\n" {
 		t.Errorf("file body = %q", b)
+	}
+}
+
+func TestRunSkillPassesConfiguredModel(t *testing.T) {
+	ws := t.TempDir()
+	h := &recordingHarness{shHarness: shHarness{payload: `{"files":[]}`}}
+	if _, err := RunSkillWithOptions(context.Background(), h, ws, "hyrum-generate", "tests.json", RunOptions{Model: "claude-opus-4-6"}); err != nil {
+		t.Fatalf("RunSkillWithOptions: %v", err)
+	}
+	if h.model != "claude-opus-4-6" {
+		t.Fatalf("model = %q", h.model)
 	}
 }
 

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -51,7 +51,9 @@ Everything the model steps read is potentially adversarial:
 - The target repository. Trusted only when it is the operator's own code.
   Untrusted for every `corpus` clone (from `--dependent <url>` or
   `--discover N`) and for `gen <local-path>` when the path is a checkout of a
-  third-party project.
+  third-party project. This includes an automatically discovered
+  `<target>/hyrum.yaml`; it is configuration supplied by the target, not by
+  the operator.
 - The dependency's source repository. Cloned from a URL returned by the
   package registry, which any registry account holder can set to anything.
 - Registry metadata (homepage, description, latest version) written into
@@ -162,6 +164,18 @@ enabled, and the same caution applies.
 `WriteFilesUnder` rejects any `path` that is absolute, empty, or contains `..`
 as a path element, then writes it through an `os.Root` opened at `--out`.
 Final and intermediate symlinks cannot take the write outside that root.
+
+An automatically discovered `hyrum.yaml` may configure `out`, but Hyrum
+requires that value and its existing symlink prefixes to resolve inside the
+target. External output paths require an operator-supplied `--config`, making
+that trust decision explicit. Hyrum ignores `work` from an automatically
+discovered config; an external work root requires an operator-supplied
+`--work` or explicit `--config`. Relative values in an explicit config use its
+directory, and absolute or `~` values are honored. Dependency-derived
+workspace paths are confined inside that selected work root, and output paths
+are confined inside their selected output root. Symlinks created or replaced
+after validation remain a time-of-check/time-of-use residual; in container
+mode the target mount is read-only during generation.
 
 ### T4: generated tests execute on the host during --verify (medium; residual)
 


### PR DESCRIPTION
gen loads hyrum.yaml from the target repository root, or from the path given to --config; discovery does not walk parents. The file sets backend, out, work, per-skill model tiers, and per-dependency baseline and skip. Explicit flags beat config and config beats built-in defaults, with a flag set to its own default value still counting as explicit. Parsing is strict: unknown and duplicate keys, aliases, nulls, wrong types, and multiple documents are rejected.

An automatically discovered file is configuration from the analyzed repository rather than from the operator, so its out value must resolve inside the target once existing symlink prefixes are resolved, and an external output path requires --out or an explicit --config. Workspace and output paths derived from a dependency name or a git remote are confined to their selected roots, which also protects corpus. A configured work root may still sit outside the target.

threatmodel.md records the target-supplied configuration input, the confinement rule, and the time-of-check/time-of-use residual for symlinks replaced after validation. New tests cover the command boundary, precedence, strict parsing, both confinement guards, and model propagation through the host and container runners.

This depends on nothing in #1 but conflicts with it in cmd/hyrum/gen.go, cmd/hyrum/gen_test.go, internal/hyrum/container_test.go, and internal/hyrum/run.go, because both change the signatures of RunSkill and runValidate. #1 is the smaller change, so merging it first and rebasing this on top keeps that to a single resolution.
