### PR TITLE
Pin Go toolchain to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/alpha-omega-security/hyrum
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	github.com/alpha-omega-security/harness v0.1.6
 	github.com/git-pkgs/brief v0.9.4


### PR DESCRIPTION
Pins the preferred Go toolchain to 1.26.6 while keeping Go 1.26 as the module language version. This clears the standard library vulnerabilities reported by govulncheck when CI selects Go 1.26.5.