### PR TITLE
Index dependency summaries in one pass

### DIFF
--- a/cmd/hyrum/surface.go
+++ b/cmd/hyrum/surface.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -52,20 +51,31 @@ func surfaceSummary(ctx context.Context, t *hyrum.Target, directOnly, asJSON boo
 		Sites     int    `json:"sites"`
 		Indexer   string `json:"indexer"`
 	}
-	var rows []row
+	var deps []hyrum.Dep
+	var depPURLs []string
 	for _, d := range t.Deps {
 		if directOnly && !d.Direct {
 			continue
 		}
+		deps = append(deps, d)
+		depPURLs = append(depPURLs, d.PURL)
+	}
+	indexed, err := usage.IndexMany(ctx, t.Path, depPURLs)
+	if err != nil {
+		return err
+	}
+
+	var rows []row
+	for _, d := range deps {
 		r := row{Name: d.Name, Ecosystem: d.Ecosystem, Version: d.Version, Scope: d.Scope}
-		if s, err := usage.Index(ctx, t.Path, d.PURL); err == nil {
+		result, ok := indexed[d.PURL]
+		if ok && result.Err == nil && result.Surface != nil {
+			s := result.Surface
 			r.Symbols = s.UsedCount()
 			for _, sym := range s.Symbols {
 				r.Sites += len(sym.Sites)
 			}
 			r.Indexer = "ok"
-		} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return err
 		} else {
 			r.Indexer = "unsupported"
 		}

--- a/internal/hyrum/usage/index.go
+++ b/internal/hyrum/usage/index.go
@@ -88,8 +88,27 @@ var skipDirs = map[string]bool{
 // identifiers as receivers, then calls outline.Refs to collect direct member
 // accesses on those receivers.
 func scan(ctx context.Context, root string, sp spec, provided []provides.ProvidedName) (*Surface, error) {
+	const key = "dependency"
+	surfaces, err := scanMany(ctx, root, sp, []scanTarget{{key: key, provided: provided}})
+	return surfaces[key], err
+}
+
+type scanTarget struct {
+	key      string
+	provided []provides.ProvidedName
+}
+
+func scanMany(
+	ctx context.Context,
+	root string,
+	sp spec,
+	targets []scanTarget,
+) (map[string]*Surface, error) {
 	exts := set(sp.exts...)
-	c := newCollector()
+	collectors := make(map[string]*collector, len(targets))
+	for _, target := range targets {
+		collectors[target.key] = newCollector()
+	}
 
 	err := walkSourceFiles(ctx, root, exts, func(path string) error {
 		src, rerr := os.ReadFile(path)
@@ -100,9 +119,13 @@ func scan(ctx context.Context, root string, sp spec, provided []provides.Provide
 			return err
 		}
 		rel, _ := filepath.Rel(root, path)
-		return scanFile(ctx, c, sp, src, rel, provided)
+		return scanFileMany(ctx, collectors, sp, src, rel, targets)
 	})
-	return c.surface(), err
+	surfaces := make(map[string]*Surface, len(collectors))
+	for key, c := range collectors {
+		surfaces[key] = c.surface()
+	}
+	return surfaces, err
 }
 
 func walkSourceFiles(
@@ -131,16 +154,21 @@ func walkSourceFiles(
 	})
 }
 
-// scanFile records symbols from one file into c. It first extracts import
-// statements and keeps those whose module string matches a provided name,
-// then traces member accesses on the local identifiers those imports bind.
-func scanFile(
+type receiverOwner struct {
+	collector *collector
+	export    string
+}
+
+// scanFileMany records symbols for every target from one parse of the file.
+// It assigns matching imports and receiver references to each target's
+// collector independently.
+func scanFileMany(
 	ctx context.Context,
-	c *collector,
+	collectors map[string]*collector,
 	sp spec,
 	src []byte,
 	rel string,
-	provided []provides.ProvidedName,
+	targets []scanTarget,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -154,44 +182,127 @@ func scanFile(
 	}
 	lines := strings.Split(string(src), "\n")
 
-	// receivers maps a local identifier to the export-side name that member
-	// accesses on it should be recorded under, so `request as rq` followed
-	// by `rq.args` is recorded as `request.args`.
-	receivers := map[string]string{}
-	if sp.seedProvided {
-		for _, n := range provided {
-			if isIdentifier(n.Name) {
-				receivers[n.Name] = n.Name
-			}
-		}
+	receivers, err := seedReceivers(ctx, sp, targets)
+	if err != nil {
+		return err
 	}
-
-	for _, imp := range imports {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if !matchesAny(provided, imp.Module) {
-			continue
-		}
-		recordImport(c, sp, imp, rel, lineAt(lines, imp.Line), receivers)
+	if err := recordMatchingImports(ctx, collectors, sp, imports, rel, lines, targets, receivers); err != nil {
+		return err
 	}
-	if len(receivers) == 0 {
+	owners := collectReceiverOwners(receivers, collectors)
+	if len(owners) == 0 {
 		return nil
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	refs, _ := outline.Refs(src, rel, keys(receivers))
+	refs, _ := outline.Refs(src, rel, keys(owners))
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	return recordRefs(ctx, owners, refs, rel, lines)
+}
+
+// receivers maps each target's local identifiers to export-side names.
+// `request as rq` followed by `rq.args` is therefore recorded as
+// `request.args` in the collector for the package that provided request.
+func seedReceivers(
+	ctx context.Context,
+	sp spec,
+	targets []scanTarget,
+) (map[string]map[string]string, error) {
+	receivers := make(map[string]map[string]string, len(targets))
+	if !sp.seedProvided {
+		return receivers, nil
+	}
+	for _, target := range targets {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		for _, n := range target.provided {
+			if !isIdentifier(n.Name) {
+				continue
+			}
+			if receivers[target.key] == nil {
+				receivers[target.key] = map[string]string{}
+			}
+			receivers[target.key][n.Name] = n.Name
+		}
+	}
+	return receivers, nil
+}
+
+func recordMatchingImports(
+	ctx context.Context,
+	collectors map[string]*collector,
+	sp spec,
+	imports []outline.Import,
+	rel string,
+	lines []string,
+	targets []scanTarget,
+	receivers map[string]map[string]string,
+) error {
+	for _, imp := range imports {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		for _, target := range targets {
+			if !matchesAny(target.provided, imp.Module) {
+				continue
+			}
+			if receivers[target.key] == nil {
+				receivers[target.key] = map[string]string{}
+			}
+			recordImport(
+				collectors[target.key],
+				sp,
+				imp,
+				rel,
+				lineAt(lines, imp.Line),
+				receivers[target.key],
+			)
+		}
+	}
+	return nil
+}
+
+func collectReceiverOwners(
+	receivers map[string]map[string]string,
+	collectors map[string]*collector,
+) map[string][]receiverOwner {
+	owners := map[string][]receiverOwner{}
+	for key, targetReceivers := range receivers {
+		for local, export := range targetReceivers {
+			owners[local] = append(owners[local], receiverOwner{
+				collector: collectors[key],
+				export:    export,
+			})
+		}
+	}
+	return owners
+}
+
+func recordRefs(
+	ctx context.Context,
+	owners map[string][]receiverOwner,
+	refs []outline.Ref,
+	rel string,
+	lines []string,
+) error {
 	for _, ref := range refs {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		base := receivers[ref.Receiver]
-		c.add(base+"."+ref.Member, kindMember, rel, ref.Line, lineAt(lines, ref.Line))
+		for _, owner := range owners[ref.Receiver] {
+			owner.collector.add(
+				owner.export+"."+ref.Member,
+				kindMember,
+				rel,
+				ref.Line,
+				lineAt(lines, ref.Line),
+			)
+		}
 	}
 	return nil
 }
@@ -290,7 +401,7 @@ func lineAt(lines []string, n int) string {
 	return strings.TrimSpace(lines[n-1])
 }
 
-func keys(m map[string]string) []string {
+func keys[V any](m map[string]V) []string {
 	out := make([]string, 0, len(m))
 	for k := range m {
 		out = append(out, k)

--- a/internal/hyrum/usage/python_test.go
+++ b/internal/hyrum/usage/python_test.go
@@ -133,3 +133,50 @@ func TestPyCuratedChainedBeforeHeuristic(t *testing.T) {
 		t.Errorf("curated PyYAML→yaml mapping not applied: %v", got)
 	}
 }
+
+func TestIndexManySeparatesPythonDependencies(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"app.py": "import flask\n" +
+			"import yaml\n" +
+			"flask.jsonify({'ok': True})\n" +
+			"yaml.safe_load('ok: true')\n",
+	})
+	purls := []string{"pkg:pypi/flask", "pkg:pypi/PyYAML@6.0"}
+	results, err := IndexMany(t.Context(), root, purls)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	flask := results[purls[0]]
+	if flask.Err != nil || flask.Surface == nil {
+		t.Fatalf("flask result = %+v", flask)
+	}
+	flaskSymbols := symbolNames(flask.Surface)
+	if flaskSymbols["flask.jsonify"] != 1 || flaskSymbols["yaml.safe_load"] != 0 {
+		t.Errorf("flask symbols = %v", flaskSymbols)
+	}
+
+	yaml := results[purls[1]]
+	if yaml.Err != nil || yaml.Surface == nil {
+		t.Fatalf("PyYAML result = %+v", yaml)
+	}
+	yamlSymbols := symbolNames(yaml.Surface)
+	if yamlSymbols["yaml.safe_load"] != 1 || yamlSymbols["flask.jsonify"] != 0 {
+		t.Errorf("PyYAML symbols = %v", yamlSymbols)
+	}
+}
+
+func TestIndexManyKeepsPerDependencyErrors(t *testing.T) {
+	root := writeTree(t, map[string]string{"app.py": "import flask\n"})
+	purls := []string{"pkg:pypi/flask", "pkg:cobol/example"}
+	results, err := IndexMany(t.Context(), root, purls)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[purls[0]].Err != nil || results[purls[0]].Surface == nil {
+		t.Fatalf("flask result = %+v", results[purls[0]])
+	}
+	if results[purls[1]].Err == nil || results[purls[1]].Surface != nil {
+		t.Fatalf("unsupported result = %+v", results[purls[1]])
+	}
+}

--- a/internal/hyrum/usage/usage.go
+++ b/internal/hyrum/usage/usage.go
@@ -53,6 +53,14 @@ type Surface struct {
 // the dependency's own source (outline.Pack) and is filled in by the caller.
 func (s *Surface) UsedCount() int { return len(s.Symbols) }
 
+// IndexResult is one dependency's result from IndexMany. Err applies only to
+// that dependency; errors that stop a shared scan are returned directly by
+// IndexMany.
+type IndexResult struct {
+	Surface *Surface
+	Err     error
+}
+
 // resolver is the SurfaceResolver used to map a dependency PURL to the
 // source-level names it provides. The curated Python catalog runs first so
 // its exact mappings win; the heuristic covers everything else.
@@ -77,26 +85,102 @@ func Ecosystems() []string {
 // Index scans root for source-level references to the dependency identified
 // by depPURL and returns the discovered surface.
 func Index(ctx context.Context, root, depPURL string) (*Surface, error) {
-	p, err := purl.Parse(depPURL)
-	if err != nil {
-		return nil, fmt.Errorf("usage: parse %q: %w", depPURL, err)
-	}
-	sp, ok := specs[p.Type]
-	if !ok {
-		return nil, fmt.Errorf("usage: no indexer for purl type %q (have: %v)", p.Type, Ecosystems())
-	}
-	res, err := resolver.ResolveSurface(ctx, provides.Package{PURL: depPURL}, provides.SurfaceOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("usage: resolve %s: %w", depPURL, err)
-	}
-	s, err := scan(ctx, root, sp, res.Surface.Provides)
+	target, err := resolveTarget(ctx, depPURL)
 	if err != nil {
 		return nil, err
 	}
-	s.PURL = depPURL
-	s.Ecosystem = p.Type
-	s.Dep = purlName(p)
+	s, err := scan(ctx, root, target.spec, target.provided)
+	if err != nil {
+		return nil, err
+	}
+	setSurfaceIdentity(s, target)
 	return s, nil
+}
+
+type resolvedTarget struct {
+	depPURL  string
+	parsed   *purl.PURL
+	spec     spec
+	provided []provides.ProvidedName
+}
+
+func resolveTarget(ctx context.Context, depPURL string) (resolvedTarget, error) {
+	p, err := purl.Parse(depPURL)
+	if err != nil {
+		return resolvedTarget{}, fmt.Errorf("usage: parse %q: %w", depPURL, err)
+	}
+	sp, ok := specs[p.Type]
+	if !ok {
+		return resolvedTarget{}, fmt.Errorf("usage: no indexer for purl type %q (have: %v)", p.Type, Ecosystems())
+	}
+	res, err := resolver.ResolveSurface(ctx, provides.Package{PURL: depPURL}, provides.SurfaceOptions{})
+	if err != nil {
+		return resolvedTarget{}, fmt.Errorf("usage: resolve %s: %w", depPURL, err)
+	}
+	return resolvedTarget{
+		depPURL:  depPURL,
+		parsed:   p,
+		spec:     sp,
+		provided: res.Surface.Provides,
+	}, nil
+}
+
+// IndexMany scans root once per represented ecosystem and returns a result
+// keyed by dependency PURL. Duplicate PURLs are resolved and scanned once.
+func IndexMany(ctx context.Context, root string, depPURLs []string) (map[string]IndexResult, error) {
+	results := make(map[string]IndexResult, len(depPURLs))
+	groups := map[string][]resolvedTarget{}
+	var ecosystems []string
+	seen := map[string]bool{}
+	for _, depPURL := range depPURLs {
+		if seen[depPURL] {
+			continue
+		}
+		seen[depPURL] = true
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		target, resolveErr := resolveTarget(ctx, depPURL)
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if resolveErr != nil {
+			results[depPURL] = IndexResult{Err: resolveErr}
+			continue
+		}
+		ecosystem := target.parsed.Type
+		if len(groups[ecosystem]) == 0 {
+			ecosystems = append(ecosystems, ecosystem)
+		}
+		groups[ecosystem] = append(groups[ecosystem], target)
+	}
+
+	for _, ecosystem := range ecosystems {
+		targets := groups[ecosystem]
+		scanTargets := make([]scanTarget, 0, len(targets))
+		for _, target := range targets {
+			scanTargets = append(scanTargets, scanTarget{
+				key:      target.depPURL,
+				provided: target.provided,
+			})
+		}
+		surfaces, err := scanMany(ctx, root, targets[0].spec, scanTargets)
+		if err != nil {
+			return nil, err
+		}
+		for _, target := range targets {
+			s := surfaces[target.depPURL]
+			setSurfaceIdentity(s, target)
+			results[target.depPURL] = IndexResult{Surface: s}
+		}
+	}
+	return results, nil
+}
+
+func setSurfaceIdentity(s *Surface, target resolvedTarget) {
+	s.PURL = target.depPURL
+	s.Ecosystem = target.parsed.Type
+	s.Dep = purlName(target.parsed)
 }
 
 func purlName(p *purl.PURL) string {


### PR DESCRIPTION
Index selected dependencies in shared source-tree passes grouped by source ecosystem. Keep dependency resolution errors isolated while avoiding one complete parse per dependency.