### PR TITLE
Match history from changed manifest lines

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,7 +21,7 @@ Before any model step runs, `stageContext` and `GatherHistory` write:
 | `usage.json` | scoped imports, refs, and configured activation strings over `target/` | usage, generate |
 | `dep-outline.md` | `outline.Pack` of `dep/`, signature-only | usage, generate |
 | `context.json` | purl, name, ecosystem, baseline version, repo URL, latest version, exported-symbol count | all |
-| `git-log.txt` | target commits selected by dependency mentions in messages or changed manifest lines | history |
+| `git-log.txt` | target commits selected by dependency mentions in messages or manifest diff excerpts | history |
 | `changelog.json` | `changelog.Between(baseline, latest)` from `dep/` (absent if none found) | history, validate |
 | `vulns.json` | osv.dev advisories for the dep's purl | history |
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -21,7 +21,7 @@ Before any model step runs, `stageContext` and `GatherHistory` write:
 | `usage.json` | scoped imports, refs, and configured activation strings over `target/` | usage, generate |
 | `dep-outline.md` | `outline.Pack` of `dep/`, signature-only | usage, generate |
 | `context.json` | purl, name, ecosystem, baseline version, repo URL, latest version, exported-symbol count | all |
-| `git-log.txt` | target's `git log --all` filtered to commits mentioning the dep | history |
+| `git-log.txt` | target commits selected by dependency mentions in messages or changed manifest lines | history |
 | `changelog.json` | `changelog.Between(baseline, latest)` from `dep/` (absent if none found) | history, validate |
 | `vulns.json` | osv.dev advisories for the dep's purl | history |
 

--- a/internal/hyrum/history.go
+++ b/internal/hyrum/history.go
@@ -27,8 +27,8 @@ type Commit struct {
 	// Files is populated for the manifest-path scan so hyrum-history can see
 	// which lockfile changed without opening the commit.
 	Files []string `json:"files,omitempty"`
-	// Changes contains added and removed manifest lines that matched the
-	// dependency name. The diff marker is retained to show each direction.
+	// Changes contains manifest diff excerpts that matched the dependency.
+	// Lockfile excerpts may include an unchanged package identity line.
 	Changes []string `json:"changes,omitempty"`
 	patch   string
 }
@@ -53,7 +53,8 @@ type HistoryIndex struct {
 // literal substring. The second pass streams `git log --all -- <manifest
 // paths>` (paths taken from brief's package-manager detections) with patches
 // so version-bump commits are captured even when the message does not name
-// the dependency. Manifest matching considers added and removed lines only.
+// the dependency. Manifest matching considers changed lines and an immediately
+// preceding package identity line when a lockfile separates name and version.
 //
 // Both passes propagate context cancellation. Zero matches for a name is a
 // valid empty result.
@@ -92,9 +93,9 @@ func BuildHistoryIndex(ctx context.Context, t *Target, deps []Dep) (*HistoryInde
 }
 
 // For returns the commits relevant to dep: message matches merged with
-// manifest-path commits whose added or removed lines mention dep, deduplicated
-// by SHA in git's original ordering (message matches first, then any
-// manifest-only commits appended).
+// manifest-path commits whose diff excerpts mention dep, deduplicated by SHA
+// in git's original ordering (message matches first, then any manifest-only
+// commits appended).
 func (h *HistoryIndex) For(dep string) []Commit {
 	name := strings.ToLower(dep)
 	manifestMatches := make(map[string]Commit)
@@ -247,7 +248,7 @@ func streamLog(ctx context.Context, repo string, paths []string, detail logDetai
 	case logNames:
 		args = append(args, "--name-only")
 	case logPatch:
-		args = append(args, "--patch", "--unified=0")
+		args = append(args, "--patch", "--unified=1")
 	}
 	if len(paths) > 0 {
 		args = append(args, "--")
@@ -298,16 +299,43 @@ func touchedManifestPaths(patch string, paths []string) []string {
 }
 
 func changedPatchLines(patch string) []string {
+	lines := strings.Split(patch, "\n")
 	var changes []string
-	for _, line := range strings.Split(patch, "\n") {
-		if strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "--- ") {
+	for i, line := range lines {
+		if isPatchChangeLine(line) {
+			changes = append(changes, line)
+		}
+		if !isManifestIdentityContext(line) {
 			continue
 		}
-		if strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
-			changes = append(changes, line)
+		excerpt := []string{line}
+		for j := i + 1; j < len(lines) && isPatchChangeLine(lines[j]); j++ {
+			excerpt = append(excerpt, lines[j])
+		}
+		if len(excerpt) > 1 {
+			changes = append(changes, strings.Join(excerpt, "\n"))
 		}
 	}
 	return changes
+}
+
+func isPatchChangeLine(line string) bool {
+	if strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "--- ") {
+		return false
+	}
+	return strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-")
+}
+
+func isManifestIdentityContext(line string) bool {
+	if !strings.HasPrefix(line, " ") {
+		return false
+	}
+	text := strings.TrimSpace(line[1:])
+	if strings.HasPrefix(text, "name = ") || strings.HasPrefix(text, `"name":`) {
+		return true
+	}
+	return strings.HasSuffix(text, ":") ||
+		(strings.HasSuffix(text, "{") && strings.Contains(text, ":"))
 }
 
 func splitOn(delim byte) bufio.SplitFunc {

--- a/internal/hyrum/history.go
+++ b/internal/hyrum/history.go
@@ -27,7 +27,10 @@ type Commit struct {
 	// Files is populated for the manifest-path scan so hyrum-history can see
 	// which lockfile changed without opening the commit.
 	Files []string `json:"files,omitempty"`
-	patch string
+	// Changes contains added and removed manifest lines that matched the
+	// dependency name. The diff marker is retained to show each direction.
+	Changes []string `json:"changes,omitempty"`
+	patch   string
 }
 
 // HistoryIndex holds the result of one full-history scan of the target,
@@ -48,9 +51,9 @@ type HistoryIndex struct {
 // The first pass streams `git log --all` with NUL/US separators and matches
 // each commit's subject+body against every name in deps as a case-insensitive
 // literal substring. The second pass streams `git log --all -- <manifest
-// paths>` (paths taken from brief's package-manager detections) with
-// --name-only so version-bump commits are captured even when the message
-// does not name the dependency.
+// paths>` (paths taken from brief's package-manager detections) with patches
+// so version-bump commits are captured even when the message does not name
+// the dependency. Manifest matching considers added and removed lines only.
 //
 // Both passes propagate context cancellation. Zero matches for a name is a
 // valid empty result.
@@ -77,6 +80,8 @@ func BuildHistoryIndex(ctx context.Context, t *Target, deps []Dep) (*HistoryInde
 	if len(paths) > 0 {
 		err = streamLog(ctx, t.Path, paths, logPatch, func(c Commit) {
 			c.Files = touchedManifestPaths(c.patch, paths)
+			c.Changes = changedPatchLines(c.patch)
+			c.patch = ""
 			idx.manifest = append(idx.manifest, c)
 		})
 		if err != nil {
@@ -87,15 +92,27 @@ func BuildHistoryIndex(ctx context.Context, t *Target, deps []Dep) (*HistoryInde
 }
 
 // For returns the commits relevant to dep: message matches merged with
-// manifest-path commits whose patch mentions dep, deduplicated by SHA in
-// git's original ordering (message matches first, then any manifest-only
-// commits appended).
+// manifest-path commits whose added or removed lines mention dep, deduplicated
+// by SHA in git's original ordering (message matches first, then any
+// manifest-only commits appended).
 func (h *HistoryIndex) For(dep string) []Commit {
 	name := strings.ToLower(dep)
+	manifestMatches := make(map[string]Commit)
+	for _, c := range h.manifest {
+		c.Changes = matchingChanges(c.Changes, name)
+		if len(c.Changes) > 0 {
+			manifestMatches[c.SHA] = c
+		}
+	}
+
 	seen := map[string]bool{}
 	out := make([]Commit, 0, len(h.byName[name]))
 	for _, c := range h.byName[name] {
 		if !seen[c.SHA] {
+			if manifest, ok := manifestMatches[c.SHA]; ok {
+				c.Files = manifest.Files
+				c.Changes = manifest.Changes
+			}
 			seen[c.SHA] = true
 			out = append(out, c)
 		}
@@ -104,32 +121,27 @@ func (h *HistoryIndex) For(dep string) []Commit {
 		if seen[c.SHA] {
 			continue
 		}
-		// A manifest commit is relevant when the diff mentions the dep name.
-		// Checking here rather than during the scan keeps the scan O(commits)
-		// instead of O(commits × deps); the manifest-touching set is small.
-		if commitMentions(c, name) {
+		if match, ok := manifestMatches[c.SHA]; ok {
 			seen[c.SHA] = true
-			out = append(out, c)
+			out = append(out, match)
 		}
 	}
 	return out
 }
 
-func commitMentions(c Commit, name string) bool {
-	if strings.Contains(strings.ToLower(c.Subject+"\n"+c.Body+"\n"+c.patch), name) {
-		return true
-	}
-	for _, f := range c.Files {
-		if strings.Contains(strings.ToLower(f), name) {
-			return true
+func matchingChanges(changes []string, name string) []string {
+	var matches []string
+	for _, change := range changes {
+		if strings.Contains(strings.ToLower(change), name) {
+			matches = append(matches, change)
 		}
 	}
-	return false
+	return matches
 }
 
 // WriteGitLog writes the commits for dep from a pre-built index to path in
-// the same `SHA date subject / body / ---` text format the hyrum-history
-// skill reads.
+// the `SHA date subject / body / manifest paths / matching changes / ---`
+// text format the hyrum-history skill reads.
 func (h *HistoryIndex) WriteGitLog(dep, path string) error {
 	var b strings.Builder
 	for _, c := range h.For(dep) {
@@ -144,14 +156,18 @@ func (h *HistoryIndex) WriteGitLog(dep, path string) error {
 			b.WriteString(strings.Join(c.Files, "\n"))
 			b.WriteByte('\n')
 		}
+		if len(c.Changes) > 0 {
+			b.WriteString(strings.Join(c.Changes, "\n"))
+			b.WriteByte('\n')
+		}
 		b.WriteString("---\n")
 	}
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }
 
-// maxLogRecord bounds a single git-log record (SHA + date + subject + body
-// + optional file list). It exists so a repository with a multi-megabyte
-// commit body cannot exhaust memory via bufio.Scanner's growing buffer.
+// maxLogRecord bounds a single git-log record (SHA + date + subject + body +
+// optional detail). It exists so a repository with a multi-megabyte commit
+// body or patch cannot exhaust memory via bufio.Scanner's growing buffer.
 const maxLogRecord = 8 << 20
 
 // logFields is the number of US-separated fields in the streamLog format
@@ -231,7 +247,7 @@ func streamLog(ctx context.Context, repo string, paths []string, detail logDetai
 	case logNames:
 		args = append(args, "--name-only")
 	case logPatch:
-		args = append(args, "--patch")
+		args = append(args, "--patch", "--unified=0")
 	}
 	if len(paths) > 0 {
 		args = append(args, "--")
@@ -279,6 +295,19 @@ func touchedManifestPaths(patch string, paths []string) []string {
 		}
 	}
 	return touched
+}
+
+func changedPatchLines(patch string) []string {
+	var changes []string
+	for _, line := range strings.Split(patch, "\n") {
+		if strings.HasPrefix(line, "+++ ") || strings.HasPrefix(line, "--- ") {
+			continue
+		}
+		if strings.HasPrefix(line, "+") || strings.HasPrefix(line, "-") {
+			changes = append(changes, line)
+		}
+	}
+	return changes
 }
 
 func splitOn(delim byte) bufio.SplitFunc {

--- a/internal/hyrum/history_test.go
+++ b/internal/hyrum/history_test.go
@@ -14,25 +14,27 @@ import (
 func gitInit(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	run := func(args ...string) {
-		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-	}
-	run("init", "-q")
+	runGit(t, dir, "init", "-q")
 	os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"dependencies":{"ws":"7.4.2"}}`), 0o644)
-	run("add", ".")
-	run("commit", "-q", "-m", "add ws dep")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "add ws dep")
 	os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"dependencies":{"ws":"8.0.0"}}`), 0o644)
-	run("commit", "-q", "-am", "bump\n\nunrelated body text\n\nsecond paragraph")
+	runGit(t, dir, "commit", "-q", "-am", "bump\n\nunrelated body text\n\nsecond paragraph")
 	os.WriteFile(filepath.Join(dir, "other.txt"), []byte("x"), 0o644)
-	run("add", ".")
-	run("commit", "-q", "-m", "fix WS handling\n\nbody with --- in it\nand more")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-q", "-m", "fix WS handling\n\nbody with --- in it\nand more")
 	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
 }
 
 func TestStreamLogParsesRecords(t *testing.T) {
@@ -99,16 +101,6 @@ func TestBuildHistoryIndexPartitions(t *testing.T) {
 
 func TestBuildHistoryIndexMatchesChangedManifestLinesOnly(t *testing.T) {
 	dir := t.TempDir()
-	run := func(args ...string) {
-		t.Helper()
-		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
-		cmd.Env = append(os.Environ(),
-			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
-			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("git %v: %v\n%s", args, err, out)
-		}
-	}
 	writePackage := func(ws, lodash string) {
 		t.Helper()
 		contents := "{\n  \"dependencies\": {\n    \"ws\": \"" + ws + "\",\n    \"lodash\": \"" + lodash + "\"\n  }\n}\n"
@@ -117,14 +109,14 @@ func TestBuildHistoryIndexMatchesChangedManifestLinesOnly(t *testing.T) {
 		}
 	}
 
-	run("init", "-q")
+	runGit(t, dir, "init", "-q")
 	writePackage("7.4.2", "4.17.20")
-	run("add", "package.json")
-	run("commit", "-q", "-m", "add dependencies")
+	runGit(t, dir, "add", "package.json")
+	runGit(t, dir, "commit", "-q", "-m", "add dependencies")
 	writePackage("7.4.2", "4.17.21")
-	run("commit", "-q", "-am", "update utility package")
+	runGit(t, dir, "commit", "-q", "-am", "update utility package")
 	writePackage("8.0.0", "4.17.21")
-	run("commit", "-q", "-am", "update ws package")
+	runGit(t, dir, "commit", "-q", "-am", "update ws package")
 
 	tgt := &Target{Path: dir, Report: &brief.Report{PackageManagers: []brief.Detection{{
 		ConfigFiles: []string{"package.json"},
@@ -165,6 +157,44 @@ func TestBuildHistoryIndexMatchesChangedManifestLinesOnly(t *testing.T) {
 	}
 }
 
+func TestBuildHistoryIndexMatchesVersionOnlyLockfileUpdate(t *testing.T) {
+	dir := gitInit(t)
+	writeLock := func(version string) {
+		t.Helper()
+		contents := "[[package]]\nname = \"serde\"\nversion = \"" + version + "\"\n"
+		if err := os.WriteFile(filepath.Join(dir, "Cargo.lock"), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeLock("1.0.0")
+	runGit(t, dir, "add", "Cargo.lock")
+	runGit(t, dir, "commit", "-q", "-m", "add lockfile")
+	writeLock("1.0.1")
+	runGit(t, dir, "commit", "-q", "-am", "update dependency")
+
+	tgt := &Target{Path: dir, Report: &brief.Report{PackageManagers: []brief.Detection{{
+		Lockfile: "Cargo.lock",
+	}}}}
+	idx, err := BuildHistoryIndex(t.Context(), tgt, []Dep{{Name: "serde"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := idx.For("serde")
+	if len(matches) != 2 {
+		t.Fatalf("serde matches = %d, want initial and version update commits: %+v", len(matches), matches)
+	}
+	if matches[0].Subject != "update dependency" {
+		t.Errorf("first match subject = %q", matches[0].Subject)
+	}
+	changes := strings.Join(matches[0].Changes, "\n")
+	for _, want := range []string{`name = "serde"`, `-version = "1.0.0"`, `+version = "1.0.1"`} {
+		if !strings.Contains(changes, want) {
+			t.Errorf("version update changes = %q, want %q", changes, want)
+		}
+	}
+}
+
 func TestTouchedManifestPathsUsesExactDiffHeaders(t *testing.T) {
 	patch := "diff --git a/packages/app/package.json b/packages/app/package.json\n"
 	paths := []string{"package.json", "packages/app/package.json"}
@@ -180,6 +210,19 @@ func TestChangedPatchLinesExcludesDiffHeadersAndContext(t *testing.T) {
 	want := []string{`-  "ws": "7.4.2"`, `+  "ws": "8.0.0"`}
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("changedPatchLines = %q, want %q", got, want)
+	}
+}
+
+func TestChangedPatchLinesAssociatesManifestIdentityContext(t *testing.T) {
+	patch := "diff --git a/Cargo.lock b/Cargo.lock\n--- a/Cargo.lock\n+++ b/Cargo.lock\n@@ -2,2 +2,2 @@\n name = \"serde\"\n-version = \"1.0.0\"\n+version = \"1.0.1\"\n"
+	matches := matchingChanges(changedPatchLines(patch), "serde")
+	if len(matches) != 1 {
+		t.Fatalf("matching changes = %q, want one lockfile excerpt", matches)
+	}
+	for _, want := range []string{`name = "serde"`, `-version = "1.0.0"`, `+version = "1.0.1"`} {
+		if !strings.Contains(matches[0], want) {
+			t.Errorf("matching change = %q, want %q", matches[0], want)
+		}
 	}
 }
 

--- a/internal/hyrum/history_test.go
+++ b/internal/hyrum/history_test.go
@@ -97,12 +97,89 @@ func TestBuildHistoryIndexPartitions(t *testing.T) {
 	}
 }
 
+func TestBuildHistoryIndexMatchesChangedManifestLinesOnly(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	writePackage := func(ws, lodash string) {
+		t.Helper()
+		contents := "{\n  \"dependencies\": {\n    \"ws\": \"" + ws + "\",\n    \"lodash\": \"" + lodash + "\"\n  }\n}\n"
+		if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	run("init", "-q")
+	writePackage("7.4.2", "4.17.20")
+	run("add", "package.json")
+	run("commit", "-q", "-m", "add dependencies")
+	writePackage("7.4.2", "4.17.21")
+	run("commit", "-q", "-am", "update utility package")
+	writePackage("8.0.0", "4.17.21")
+	run("commit", "-q", "-am", "update ws package")
+
+	tgt := &Target{Path: dir, Report: &brief.Report{PackageManagers: []brief.Detection{{
+		ConfigFiles: []string{"package.json"},
+	}}}}
+	idx, err := BuildHistoryIndex(t.Context(), tgt, []Dep{{Name: "ws"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches := idx.For("ws")
+	if len(matches) != 2 {
+		t.Fatalf("ws matches = %d, want initial and ws update commits: %+v", len(matches), matches)
+	}
+	if matches[0].Subject != "update ws package" {
+		t.Errorf("first match subject = %q", matches[0].Subject)
+	}
+	if got := strings.Join(matches[0].Changes, "\n"); !strings.Contains(got, `-    "ws": "7.4.2",`) || !strings.Contains(got, `+    "ws": "8.0.0",`) {
+		t.Errorf("ws update changes = %q", got)
+	}
+	for _, match := range matches {
+		if match.Subject == "update utility package" {
+			t.Errorf("unchanged manifest context selected unrelated commit: %+v", match)
+		}
+	}
+
+	out := filepath.Join(t.TempDir(), "git-log.txt")
+	if err := idx.WriteGitLog("ws", out); err != nil {
+		t.Fatal(err)
+	}
+	contents, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(contents), `-    "ws": "7.4.2",`) || !strings.Contains(string(contents), `+    "ws": "8.0.0",`) {
+		t.Errorf("git-log.txt lacks matching manifest evidence:\n%s", contents)
+	}
+	if strings.Contains(string(contents), "lodash") {
+		t.Errorf("git-log.txt contains a non-matching manifest line:\n%s", contents)
+	}
+}
+
 func TestTouchedManifestPathsUsesExactDiffHeaders(t *testing.T) {
 	patch := "diff --git a/packages/app/package.json b/packages/app/package.json\n"
 	paths := []string{"package.json", "packages/app/package.json"}
 	got := touchedManifestPaths(patch, paths)
 	if len(got) != 1 || got[0] != "packages/app/package.json" {
 		t.Fatalf("touchedManifestPaths = %q", got)
+	}
+}
+
+func TestChangedPatchLinesExcludesDiffHeadersAndContext(t *testing.T) {
+	patch := "diff --git a/package.json b/package.json\n--- a/package.json\n+++ b/package.json\n@@ -1,3 +1,3 @@\n {\n-  \"ws\": \"7.4.2\"\n+  \"ws\": \"8.0.0\"\n }\n"
+	got := changedPatchLines(patch)
+	want := []string{`-  "ws": "7.4.2"`, `+  "ws": "8.0.0"`}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("changedPatchLines = %q, want %q", got, want)
 	}
 }
 

--- a/skills/hyrum-history/SKILL.md
+++ b/skills/hyrum-history/SKILL.md
@@ -18,7 +18,7 @@ Your working directory is the workspace root. Every path below is relative to it
 
 - `target/` — the repository whose history you are mining (read-only, full clone)
 - `context.json` — `{purl, name, ecosystem, version, repo, latest, target}`
-- `git-log.txt`: target commits selected by dependency mentions in messages or changed manifest lines. Records contain the subject, body, touched manifest paths, and matching `+`/`-` lines, with `---` separators.
+- `git-log.txt`: target commits selected by dependency mentions in messages or manifest diff excerpts. Records contain the subject, body, touched manifest paths, and matching diff excerpts, with `---` separators. An unchanged package identity line may precede changed lockfile version lines.
 - `changelog.json` — parsed entries from the dependency's changelog (may be absent)
 - `vulns.json` — advisories affecting the dependency (may be absent)
 - `breaks.json` — write your output here per `schema.json`

--- a/skills/hyrum-history/SKILL.md
+++ b/skills/hyrum-history/SKILL.md
@@ -18,7 +18,7 @@ Your working directory is the workspace root. Every path below is relative to it
 
 - `target/` — the repository whose history you are mining (read-only, full clone)
 - `context.json` — `{purl, name, ecosystem, version, repo, latest, target}`
-- `git-log.txt` — target commits mentioning the dependency name (subject + body, `---` separated)
+- `git-log.txt`: target commits selected by dependency mentions in messages or changed manifest lines. Records contain the subject, body, touched manifest paths, and matching `+`/`-` lines, with `---` separators.
 - `changelog.json` — parsed entries from the dependency's changelog (may be absent)
 - `vulns.json` — advisories affecting the dependency (may be absent)
 - `breaks.json` — write your output here per `schema.json`


### PR DESCRIPTION
Match dependency history against added and removed manifest lines instead of unchanged diff context. Record the matching manifest paths and lines with each selected commit.