### PR TITLE
Partition generation by symbols and sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,11 @@ local runtimes are required even when `--container` is set.
 ```
 hyrum surface <path>                  per-dep usage summary; no model calls
 hyrum surface --dep X <path>          symbol-level detail for one dep
+hyrum surface --dep X --symbol X.y ... inspect selected exact symbols
 hyrum surface --scope test <path>     restrict the summary to test usage
 hyrum gen --dep X --run <path>        generate tests for X into tests/hyrum/
+hyrum gen --dep X --batch-size 40 ... cap each model batch at 40 symbols
+hyrum gen --dep X --batch-sites 500 ... cap each model batch at 500 sites
 hyrum gen --dep X --run --verify ...  also run tests at baseline and latest
 hyrum check --dep X@<ver> <path>      run existing tests/hyrum/X against X@ver
 hyrum corpus --upstream <purl> \
@@ -216,17 +219,31 @@ Static sites are classified as `production`, `test`, `example`, or
 reports separate production, test, and other site counts. `gen` and `corpus`
 stage production sites by default. Repeat `--scope` to select more than one
 scope. `surface` and `gen` also accept repeatable `--include` and `--exclude`
-relative path prefixes; exclusions take precedence.
+relative path prefixes; exclusions take precedence. Repeatable `--symbol`
+values select exact, case-sensitive static symbol names and require one
+explicit `--dep`.
+
+`gen --batch-size N` caps symbol entries per model batch, while
+`--batch-sites N` caps static sites. The selected symbols and their sites are
+sorted before partitioning. A symbol with more sites than the limit is split
+across batches. History mining runs once, and its contracts are included in
+the first batch. When a run needs several batches, generated files are placed
+under `batch-001/`, `batch-002/`, and so on within the dependency suite.
+Verification and validation run once over the merged files and traced surface.
+`meta.json` records the symbols, site count, backend session, cost, notes, and
+recovered steps for each batch. A staging run without `--run` writes each
+batch's `usage.json` under the workspace's `batches/` directory for inspection.
 
 `gen` stages a workspace with the target's static usage of the dependency
 (`usage.json`), a signature-only outline of the dependency's source
 (`dep-outline.md`), the target's git commits mentioning the dependency, its
-OSV advisories, and its parsed changelog. Three model steps then run in
-sequence: `hyrum-usage` follows the static entry points through instances and
-options bags to record the actual call surface; `hyrum-history` filters the
-history inputs down to a list of past compatibility fixes with evidence for
-each; `hyrum-generate` writes tests that mirror the observed calls and cite
-the source line or commit each was derived from. With `--verify`, supported
+OSV advisories, and its parsed changelog. Without batching, three model steps
+run in sequence: `hyrum-usage` follows the static entry points through
+instances and options bags to record the actual call surface;
+`hyrum-history` filters the history inputs down to a list of past compatibility
+fixes with evidence for each; `hyrum-generate` writes tests that mirror the
+observed calls and cite the source line or commit each was derived from. With
+`--verify`, supported
 tests are run in a scratch directory against the target's baseline version and
 the dependency's latest release. A fourth `hyrum-validate` step then classifies
 latest-version failures as real behaviour changes, over-specific assertions,

--- a/cmd/hyrum/batch.go
+++ b/cmd/hyrum/batch.go
@@ -1,0 +1,368 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/alpha-omega-security/hyrum/internal/hyrum"
+	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
+)
+
+type generationBatchMetadata struct {
+	Number         int      `json:"number"`
+	Symbols        []string `json:"symbols"`
+	Sites          int      `json:"sites"`
+	SessionID      string   `json:"session_id,omitempty"`
+	CostUSD        float64  `json:"cost_usd"`
+	Notes          string   `json:"notes,omitempty"`
+	RecoveredSteps []string `json:"recovered_steps,omitempty"`
+}
+
+type batchedGeneration struct {
+	Generate       hyrum.GenerateResult
+	LastResult     *hyrum.RunResult
+	TotalCost      float64
+	HistoryCost    float64
+	RecoveredSteps []string
+	Batches        []generationBatchMetadata
+}
+
+type completedGenerationBatch struct {
+	Metadata       generationBatchMetadata
+	Generate       hyrum.GenerateResult
+	Result         *hyrum.RunResult
+	Trace          json.RawMessage
+	RecoveredSteps []string
+}
+
+type tracedSurface struct {
+	EntryPoints []json.RawMessage `json:"entry_points,omitempty"`
+	Calls       []json.RawMessage `json:"calls"`
+	Notes       string            `json:"notes,omitempty"`
+}
+
+func readUsageSurface(path string) (*usage.Surface, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var surface usage.Surface
+	if err := json.Unmarshal(contents, &surface); err != nil {
+		return nil, err
+	}
+	return &surface, nil
+}
+
+func stageUsageBatches(ws string, batches []*usage.Surface) error {
+	for i, batch := range batches {
+		dir := filepath.Join(ws, "batches", batchDirectory(i+1))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		if err := writeJSON(filepath.Join(dir, "usage.json"), batch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func batchDirectory(number int) string {
+	return "batch-" + fmt.Sprintf("%03d", number)
+}
+
+func (p *pipeline) runBatchedGenerateSkills(
+	ctx context.Context,
+	runner hyrum.Runner,
+	ws, depName string,
+	batches []*usage.Surface,
+) (*batchedGeneration, error) {
+	if len(batches) == 0 {
+		return nil, fmt.Errorf("no usage batches")
+	}
+
+	run := &batchedGeneration{Batches: make([]generationBatchMetadata, 0, len(batches))}
+	breaks, historyCost, historyRecoveries, err := p.runBatchHistory(ctx, runner, ws, depName)
+	if err != nil {
+		return nil, err
+	}
+	run.HistoryCost = historyCost
+	run.TotalCost = historyCost
+	run.RecoveredSteps = append(run.RecoveredSteps, historyRecoveries...)
+
+	var traced []json.RawMessage
+	var notes []string
+	for i, batch := range batches {
+		number := i + 1
+		completed, err := p.runGenerationBatch(ctx, runner, ws, depName, batch, breaks, number, len(batches))
+		if err != nil {
+			return nil, err
+		}
+		run.TotalCost += completed.Metadata.CostUSD
+		run.Batches = append(run.Batches, completed.Metadata)
+		run.LastResult = completed.Result
+		run.Generate.Files = append(run.Generate.Files, completed.Generate.Files...)
+		run.RecoveredSteps = append(run.RecoveredSteps, completed.RecoveredSteps...)
+		if completed.Trace != nil {
+			traced = append(traced, completed.Trace)
+		}
+		if completed.Generate.Notes != "" {
+			notes = append(notes, fmt.Sprintf("batch %d: %s", number, completed.Generate.Notes))
+		}
+	}
+
+	run.Generate.Notes = strings.Join(notes, "\n")
+	if err := restoreBatchedWorkspace(ws, batches, breaks, traced, run.Generate); err != nil {
+		return nil, err
+	}
+	return run, nil
+}
+
+func (p *pipeline) runBatchHistory(
+	ctx context.Context,
+	runner hyrum.Runner,
+	ws, depName string,
+) ([]byte, float64, []string, error) {
+	breaksPath := filepath.Join(ws, "breaks.json")
+	_ = os.Remove(breaksPath)
+	result, err := p.runGenerationStep(ctx, runner, ws, depName, skillSteps[1])
+	if err != nil {
+		return nil, 0, nil, nil
+	}
+	breaks := append([]byte(nil), result.Output...)
+	if err := os.WriteFile(breaksPath, breaks, 0o644); err != nil {
+		return nil, 0, nil, err
+	}
+	var recovered []string
+	if result.BackendError != "" {
+		recovered = append(recovered, skillSteps[1].name)
+	}
+	return breaks, result.CostUSD, recovered, nil
+}
+
+func (p *pipeline) runGenerationBatch(
+	ctx context.Context,
+	runner hyrum.Runner,
+	ws, depName string,
+	batch *usage.Surface,
+	breaks []byte,
+	number, total int,
+) (*completedGenerationBatch, error) {
+	fmt.Fprintf(os.Stderr, "  [batch %d/%d: %d symbol(s)]\n", number, total, len(batch.Symbols))
+	if err := prepareGenerationBatch(ws, batch, breaks, number); err != nil {
+		return nil, err
+	}
+	completed := &completedGenerationBatch{Metadata: generationBatchMetadata{
+		Number: number, Symbols: usageSymbolNames(batch), Sites: usageSiteCount(batch),
+	}}
+
+	usageResult, usageErr := p.runGenerationStep(ctx, runner, ws, depName, skillSteps[0])
+	if usageErr == nil {
+		if err := completed.recordUsageResult(ws, usageResult); err != nil {
+			return nil, err
+		}
+	}
+
+	_ = os.Remove(filepath.Join(ws, "tests.json"))
+	generateResult, err := p.runGenerationStep(ctx, runner, ws, depName, skillSteps[2])
+	if err != nil {
+		return nil, err
+	}
+	if err := completed.recordGenerateResult(ws, generateResult, number, total); err != nil {
+		return nil, err
+	}
+	return completed, nil
+}
+
+func prepareGenerationBatch(ws string, batch *usage.Surface, breaks []byte, number int) error {
+	if err := writeJSON(filepath.Join(ws, "usage.json"), batch); err != nil {
+		return err
+	}
+	breaksPath := filepath.Join(ws, "breaks.json")
+	if number == 1 && len(breaks) > 0 {
+		return os.WriteFile(breaksPath, breaks, 0o644)
+	}
+	if err := os.Remove(breaksPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	_ = os.Remove(filepath.Join(ws, "surface.json"))
+	return nil
+}
+
+func (b *completedGenerationBatch) recordUsageResult(ws string, result *hyrum.RunResult) error {
+	b.Metadata.CostUSD += result.CostUSD
+	if result.BackendError != "" {
+		b.Metadata.RecoveredSteps = append(b.Metadata.RecoveredSteps, skillSteps[0].name)
+		b.RecoveredSteps = append(b.RecoveredSteps, skillSteps[0].name+" batch "+strconv.Itoa(b.Metadata.Number))
+	}
+	b.Trace = append(json.RawMessage(nil), result.Output...)
+	if err := os.WriteFile(filepath.Join(ws, "surface.json"), result.Output, 0o644); err != nil {
+		return err
+	}
+	return writeBatchRaw(ws, b.Metadata.Number, "surface.json", result.Output)
+}
+
+func (b *completedGenerationBatch) recordGenerateResult(
+	ws string,
+	result *hyrum.RunResult,
+	number, total int,
+) error {
+	b.Metadata.CostUSD += result.CostUSD
+	b.Metadata.SessionID = result.SessionID
+	if result.BackendError != "" {
+		b.Metadata.RecoveredSteps = append(b.Metadata.RecoveredSteps, skillSteps[2].name)
+		b.RecoveredSteps = append(b.RecoveredSteps, skillSteps[2].name+" batch "+strconv.Itoa(number))
+	}
+	if err := result.Decode(&b.Generate); err != nil {
+		return fmt.Errorf("decode tests.json batch %d: %w", number, err)
+	}
+	files, err := prefixBatchFiles(b.Generate.Files, number, total)
+	if err != nil {
+		return fmt.Errorf("batch %d: %w", number, err)
+	}
+	b.Generate.Files = files
+	b.Metadata.Notes = b.Generate.Notes
+	b.Result = result
+	return writeBatchRaw(ws, number, "tests.json", result.Output)
+}
+
+func restoreBatchedWorkspace(
+	ws string,
+	batches []*usage.Surface,
+	breaks []byte,
+	traced []json.RawMessage,
+	generated hyrum.GenerateResult,
+) error {
+	if err := writeJSON(filepath.Join(ws, "usage.json"), mergeUsageBatches(batches)); err != nil {
+		return err
+	}
+	if len(breaks) > 0 {
+		if err := os.WriteFile(filepath.Join(ws, "breaks.json"), breaks, 0o644); err != nil {
+			return err
+		}
+	}
+	if err := restoreMergedTrace(ws, traced); err != nil {
+		return err
+	}
+	return writeJSON(filepath.Join(ws, "tests.json"), generated)
+}
+
+func restoreMergedTrace(ws string, traced []json.RawMessage) error {
+	surface, err := mergeTracedSurfaces(traced)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  merge surface.json: %v (validation will use usage.json)\n", err)
+		_ = os.Remove(filepath.Join(ws, "surface.json"))
+		return nil
+	}
+	if surface == nil {
+		return nil
+	}
+	return writeJSON(filepath.Join(ws, "surface.json"), surface)
+}
+
+func writeBatchRaw(ws string, number int, name string, contents []byte) error {
+	return os.WriteFile(filepath.Join(ws, "batches", batchDirectory(number), name), contents, 0o644)
+}
+
+func usageSymbolNames(surface *usage.Surface) []string {
+	names := make([]string, 0, len(surface.Symbols))
+	for _, symbol := range surface.Symbols {
+		names = append(names, symbol.Name)
+	}
+	return names
+}
+
+func usageSiteCount(surface *usage.Surface) int {
+	count := 0
+	for _, symbol := range surface.Symbols {
+		count += len(symbol.Sites)
+	}
+	return count
+}
+
+func mergeUsageBatches(batches []*usage.Surface) *usage.Surface {
+	merged := *batches[0]
+	merged.Symbols = nil
+	positions := map[string]int{}
+	for _, batch := range batches {
+		for _, symbol := range batch.Symbols {
+			position, ok := positions[symbol.Name]
+			if !ok {
+				positions[symbol.Name] = len(merged.Symbols)
+				symbol.Sites = append([]usage.Site(nil), symbol.Sites...)
+				merged.Symbols = append(merged.Symbols, symbol)
+				continue
+			}
+			merged.Symbols[position].Sites = append(merged.Symbols[position].Sites, symbol.Sites...)
+		}
+	}
+	return &merged
+}
+
+func prefixBatchFiles(files []hyrum.GeneratedFile, number, total int) ([]hyrum.GeneratedFile, error) {
+	prefixed := make([]hyrum.GeneratedFile, len(files))
+	for i, file := range files {
+		clean := filepath.Clean(file.Path)
+		if clean == "." || strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+			return nil, fmt.Errorf("refusing path %q", file.Path)
+		}
+		file.Path = clean
+		if total > 1 {
+			file.Path = filepath.Join(batchDirectory(number), clean)
+		}
+		prefixed[i] = file
+	}
+	return prefixed, nil
+}
+
+func mergeTracedSurfaces(outputs []json.RawMessage) (*tracedSurface, error) {
+	if len(outputs) == 0 {
+		return nil, nil
+	}
+	merged := &tracedSurface{Calls: []json.RawMessage{}}
+	entrySeen := map[string]bool{}
+	callSeen := map[string]bool{}
+	var notes []string
+	for i, output := range outputs {
+		var part tracedSurface
+		if err := json.Unmarshal(output, &part); err != nil {
+			return nil, fmt.Errorf("batch %d: %w", i+1, err)
+		}
+		merged.EntryPoints = appendUniqueJSON(merged.EntryPoints, part.EntryPoints, entrySeen)
+		merged.Calls = appendUniqueJSON(merged.Calls, part.Calls, callSeen)
+		if part.Notes != "" {
+			notes = append(notes, fmt.Sprintf("batch %d: %s", i+1, part.Notes))
+		}
+	}
+	merged.Notes = strings.Join(notes, "\n")
+	return merged, nil
+}
+
+func appendUniqueJSON(dst, values []json.RawMessage, seen map[string]bool) []json.RawMessage {
+	for _, value := range values {
+		key := string(value)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		dst = append(dst, value)
+	}
+	return dst
+}
+
+func addBatchMetadata(meta map[string]any, symbols, sites int, run *batchedGeneration) {
+	delete(meta, "session_id")
+	meta["batch_count"] = len(run.Batches)
+	meta["history_cost_usd"] = run.HistoryCost
+	meta["batches"] = run.Batches
+	if symbols > 0 {
+		meta["batch_size"] = symbols
+	}
+	if sites > 0 {
+		meta["batch_sites"] = sites
+	}
+}

--- a/cmd/hyrum/batch_test.go
+++ b/cmd/hyrum/batch_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/alpha-omega-security/harness"
+	"github.com/alpha-omega-security/hyrum/internal/hyrum"
+	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
+)
+
+type batchingRunner struct {
+	calls       []string
+	usageInputs [][]string
+	breaksSeen  []bool
+	generated   int
+}
+
+func (r *batchingRunner) RunSkill(
+	_ context.Context,
+	_ harness.Harness,
+	ws, name, _ string,
+	_ hyrum.RunOptions,
+) (*hyrum.RunResult, error) {
+	r.calls = append(r.calls, name)
+	switch name {
+	case "hyrum-history":
+		return &hyrum.RunResult{Output: json.RawMessage(`{"breaks":[]}`), CostUSD: 0.1}, nil
+	case "hyrum-usage":
+		surface, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+		if err != nil {
+			return nil, err
+		}
+		r.usageInputs = append(r.usageInputs, usageSymbolNames(surface))
+		output, err := json.Marshal(tracedSurface{
+			Calls: []json.RawMessage{json.RawMessage(`{"member":"shared","sites":[]}`)},
+			Notes: "traced",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &hyrum.RunResult{Output: output, CostUSD: 0.2}, nil
+	case "hyrum-generate":
+		_, err := os.Stat(filepath.Join(ws, "breaks.json"))
+		r.breaksSeen = append(r.breaksSeen, err == nil)
+		r.generated++
+		output, err := json.Marshal(hyrum.GenerateResult{
+			Files: []hyrum.GeneratedFile{{Path: "contract.test.js", Content: "// batch\n"}},
+			Notes: "generated",
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &hyrum.RunResult{
+			Output: output, CostUSD: 0.3, SessionID: "session-" + batchDirectory(r.generated),
+		}, nil
+	default:
+		return nil, nil
+	}
+}
+
+func TestRunBatchedGenerateSkillsMergesOutputsAndMetadata(t *testing.T) {
+	ws := t.TempDir()
+	surface := &usage.Surface{Dep: "sqlalchemy", Symbols: []usage.Symbol{
+		{Name: "zeta", Sites: []usage.Site{{File: "z.py"}}},
+		{Name: "alpha", Sites: []usage.Site{{File: "a.py"}}},
+		{Name: "middle", Sites: []usage.Site{{File: "m.py"}}},
+	}}
+	batches := usage.PartitionSurface(surface, 2, 0)
+	if err := stageUsageBatches(ws, batches); err != nil {
+		t.Fatal(err)
+	}
+	runner := &batchingRunner{}
+	p := &pipeline{h: harness.ClaudeHarness{}}
+
+	run, err := p.runBatchedGenerateSkills(t.Context(), runner, ws, "sqlalchemy", batches)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []string{"hyrum-history", "hyrum-usage", "hyrum-generate", "hyrum-usage", "hyrum-generate"}
+	if !reflect.DeepEqual(runner.calls, wantCalls) {
+		t.Fatalf("calls = %v, want %v", runner.calls, wantCalls)
+	}
+	wantInputs := [][]string{{"alpha", "middle"}, {"zeta"}}
+	if !reflect.DeepEqual(runner.usageInputs, wantInputs) {
+		t.Fatalf("usage inputs = %v, want %v", runner.usageInputs, wantInputs)
+	}
+	if !reflect.DeepEqual(runner.breaksSeen, []bool{true, false}) {
+		t.Fatalf("breaks visibility = %v", runner.breaksSeen)
+	}
+	if len(run.Generate.Files) != 2 || run.Generate.Files[0].Path != "batch-001/contract.test.js" || run.Generate.Files[1].Path != "batch-002/contract.test.js" {
+		t.Fatalf("generated files = %+v", run.Generate.Files)
+	}
+	if len(run.Batches) != 2 || !reflect.DeepEqual(run.Batches[0].Symbols, []string{"alpha", "middle"}) || run.Batches[0].Sites != 2 {
+		t.Fatalf("batch metadata = %+v", run.Batches)
+	}
+	if run.TotalCost < 1.09 || run.TotalCost > 1.11 || run.HistoryCost != 0.1 {
+		t.Fatalf("costs = total %v, history %v", run.TotalCost, run.HistoryCost)
+	}
+
+	staged, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := usageSymbolNames(staged); !reflect.DeepEqual(got, []string{"alpha", "middle", "zeta"}) {
+		t.Fatalf("restored usage = %v", got)
+	}
+	contents, err := os.ReadFile(filepath.Join(ws, "surface.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var traced tracedSurface
+	if err := json.Unmarshal(contents, &traced); err != nil {
+		t.Fatal(err)
+	}
+	if len(traced.Calls) != 1 {
+		t.Fatalf("merged calls = %s", contents)
+	}
+	for _, path := range []string{
+		filepath.Join(ws, "batches", "batch-001", "usage.json"),
+		filepath.Join(ws, "batches", "batch-001", "surface.json"),
+		filepath.Join(ws, "batches", "batch-001", "tests.json"),
+		filepath.Join(ws, "batches", "batch-002", "tests.json"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("batch artifact %s: %v", path, err)
+		}
+	}
+
+	meta := generationMeta("target", hyrum.Dep{Name: "sqlalchemy"}, run.LastResult, run.Generate, run.TotalCost)
+	addBatchMetadata(meta, 2, 500, run)
+	if _, ok := meta["session_id"]; ok {
+		t.Fatalf("top-level session retained for a multi-session run: %v", meta)
+	}
+	if meta["batch_count"] != 2 || meta["batch_size"] != 2 || meta["batch_sites"] != 500 {
+		t.Fatalf("merged metadata = %v", meta)
+	}
+}
+
+func TestMergeUsageBatchesReassemblesSplitSymbol(t *testing.T) {
+	surface := &usage.Surface{Symbols: []usage.Symbol{{
+		Name: "Session", Sites: []usage.Site{
+			{File: "d.py", Line: 4}, {File: "b.py", Line: 2},
+			{File: "c.py", Line: 3}, {File: "a.py", Line: 1},
+		},
+	}}}
+	batches := usage.PartitionSurface(surface, 0, 2)
+	merged := mergeUsageBatches(batches)
+	if len(batches) != 2 || len(merged.Symbols) != 1 || len(merged.Symbols[0].Sites) != 4 {
+		t.Fatalf("merged usage = %+v from %+v", merged.Symbols, batches)
+	}
+	if merged.Symbols[0].Sites[0].File != "a.py" || merged.Symbols[0].Sites[3].File != "d.py" {
+		t.Fatalf("merged site order = %+v", merged.Symbols[0].Sites)
+	}
+}
+
+func TestPrefixBatchFilesRejectsUnsafePathsBeforeJoining(t *testing.T) {
+	for _, path := range []string{"../escape.js", "/absolute.js", "."} {
+		if _, err := prefixBatchFiles([]hyrum.GeneratedFile{{Path: path}}, 1, 2); err == nil {
+			t.Errorf("path %q accepted", path)
+		}
+	}
+}

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -27,11 +27,13 @@ import (
 // is fatal because there is nothing to write without it. maxTurns overrides
 // harness.DefaultMaxTurns per skill; the values reflect observed turn counts
 // on small targets with headroom for larger dependencies and changelogs.
-var skillSteps = []struct {
+type skillStep struct {
 	name, out string
 	required  bool
 	maxTurns  int
-}{
+}
+
+var skillSteps = []skillStep{
 	{"hyrum-usage", "surface.json", false, 40},
 	{"hyrum-history", "breaks.json", false, 50},
 	{"hyrum-generate", "tests.json", true, 60},
@@ -77,8 +79,9 @@ func defaultGenOptions() genOptions {
 func cmdGen(ctx context.Context, args []string) error {
 	fs := newFlags("gen")
 	defaults := defaultGenOptions()
-	var deps, scopes, includes, excludes stringList
+	var deps, symbols, scopes, includes, excludes stringList
 	fs.Var(&deps, "dep", "dependency name to generate for (repeatable); default: all direct runtime deps")
+	fs.Var(&symbols, "symbol", "exact dependency symbol to include (repeatable; requires one --dep)")
 	fs.Var(&scopes, "scope", "usage scope to include: production, test, example, or documentation (repeatable); default: production")
 	fs.Var(&includes, "include", "relative path prefix to include when indexing usage (repeatable)")
 	fs.Var(&excludes, "exclude", "relative path prefix to exclude when indexing usage (repeatable)")
@@ -87,6 +90,8 @@ func cmdGen(ctx context.Context, args []string) error {
 	work := fs.String("work", defaults.work, "working directory for clones and skill workspaces")
 	backend := fs.String("backend", defaults.backend, "harness backend: "+harness.Names())
 	run := fs.Bool("run", false, "actually invoke the backend (otherwise stage only)")
+	batchSize := fs.Int("batch-size", 0, "maximum symbol entries per model batch; zero disables this limit")
+	batchSites := fs.Int("batch-sites", 0, "maximum static sites per model batch; zero disables this limit")
 	container := fs.String("container", "", "run the backend in a container using this image (\"default\" for "+hyrum.DefaultRunnerImage+")")
 	verify := fs.Bool("verify", false, "after generating, run the tests against the baseline and latest dep versions and record results in meta.json")
 	if err := fs.Parse(args); err != nil {
@@ -94,6 +99,15 @@ func cmdGen(ctx context.Context, args []string) error {
 	}
 	if fs.NArg() > 1 {
 		return fmt.Errorf("unexpected arguments after <path>: %v (flags must precede <path>)", fs.Args()[1:])
+	}
+	if len(symbols) > 0 && len(deps) != 1 {
+		return fmt.Errorf("--symbol requires exactly one --dep")
+	}
+	if *batchSize < 0 {
+		return fmt.Errorf("--batch-size must be zero or greater")
+	}
+	if *batchSites < 0 {
+		return fmt.Errorf("--batch-sites must be zero or greater")
 	}
 	usageOptions, err := resolveUsageOptions(scopes, includes, excludes, []usage.Scope{usage.ScopeProduction})
 	if err != nil {
@@ -145,6 +159,9 @@ func cmdGen(ctx context.Context, args []string) error {
 	p.models = models
 	p.verify = *verify
 	p.usageOptions = usageOptions
+	p.symbols = append([]string(nil), symbols...)
+	p.batchSize = *batchSize
+	p.batchSites = *batchSites
 	return p.genAll(ctx, t, selected)
 }
 
@@ -290,6 +307,14 @@ type pipeline struct {
 	outRoot      string
 	run          bool
 	usageOptions usage.IndexOptions
+	// symbols limits generation to exact static symbol names.
+	symbols []string
+	// batchSize is the maximum number of symbols sent through model steps in
+	// one batch. Zero disables the symbol limit.
+	batchSize int
+	// batchSites limits static sites per batch and can split one symbol's sites
+	// across batches. Zero disables the site limit.
+	batchSites int
 	// models maps skill names to backend-owned model IDs resolved from the
 	// portable mid/high/max tiers in hyrum.yaml.
 	models map[string]string
@@ -300,6 +325,14 @@ type pipeline struct {
 	// verify runs the generated tests against baseline and latest after
 	// writing them and records results in meta.json.
 	verify bool
+}
+
+type generationExecution struct {
+	Result         *hyrum.RunResult
+	Generate       hyrum.GenerateResult
+	TotalCost      float64
+	RecoveredSteps []string
+	Batch          *batchedGeneration
 }
 
 // newPipeline builds a pipeline from the flags gen and corpus share.
@@ -360,14 +393,29 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if err := prepareWorkspace(ws); err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
-	depDir, latest, err := stageContext(ctx, t, targetDir, d, ws, p.rc, p.usageOptions)
+	depDir, latest, err := stageContext(ctx, t, targetDir, d, ws, p.rc, p.usageOptions, p.symbols)
 	if err != nil {
 		return fmt.Errorf("stage: %w", err)
+	}
+	var batches []*usage.Surface
+	if p.batchingEnabled() {
+		surface, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+		if err != nil {
+			return fmt.Errorf("read staged usage: %w", err)
+		}
+		batches = usage.PartitionSurface(surface, p.batchSize, p.batchSites)
+		if err := stageUsageBatches(ws, batches); err != nil {
+			return fmt.Errorf("stage usage batches: %w", err)
+		}
 	}
 	if err := hyrum.GatherHistory(ctx, idx, d, depDir, latest, ws); err != nil {
 		fmt.Fprintf(os.Stderr, "  %s: history: %v\n", d.Name, err)
 	}
 	if !p.run {
+		if p.batchingEnabled() {
+			fmt.Printf("staged %s: %d batch(es) under %s; --run executes and merges them\n", d.Name, len(batches), filepath.Join(ws, "batches"))
+			return nil
+		}
 		last := skillSteps[len(skillSteps)-1]
 		job := harness.Job{
 			Workspace: ws, SrcDir: hyrum.TargetSubdir, SkillName: last.name,
@@ -382,20 +430,23 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if runner == nil {
 		runner = hyrum.ContainerRunner{Image: p.containerImage, TargetPath: t.Path}
 	}
-	res, totalCost, recoveredSteps, err := p.runGenerateSkills(ctx, runner, ws, d.Name)
+	execution, err := p.runSelectedGeneration(ctx, runner, ws, d.Name, batches)
 	if err != nil {
 		return err
 	}
-	var gen hyrum.GenerateResult
-	if err := res.Decode(&gen); err != nil {
-		return fmt.Errorf("decode tests.json: %w", err)
-	}
+	res := execution.Result
+	gen := execution.Generate
+	totalCost := execution.TotalCost
+	recoveredSteps := execution.RecoveredSteps
 
 	written, err := hyrum.ReplaceFilesUnder(p.outRoot, outRel, gen.Files)
 	if err != nil {
 		return fmt.Errorf("write: %w", err)
 	}
 	meta := generationMeta(targetDir, d, res, gen, totalCost)
+	if execution.Batch != nil {
+		addBatchMetadata(meta, p.batchSize, p.batchSites, execution.Batch)
+	}
 	if p.verify {
 		verify := p.runVerify(ctx, ws, d, latest, gen.Files)
 		meta["verify"] = verify
@@ -420,6 +471,39 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	return nil
 }
 
+func (p *pipeline) runSelectedGeneration(
+	ctx context.Context,
+	runner hyrum.Runner,
+	ws, depName string,
+	batches []*usage.Surface,
+) (*generationExecution, error) {
+	if p.batchingEnabled() {
+		run, err := p.runBatchedGenerateSkills(ctx, runner, ws, depName, batches)
+		if err != nil {
+			return nil, err
+		}
+		return &generationExecution{
+			Result: run.LastResult, Generate: run.Generate, TotalCost: run.TotalCost,
+			RecoveredSteps: run.RecoveredSteps, Batch: run,
+		}, nil
+	}
+	result, cost, recovered, err := p.runGenerateSkills(ctx, runner, ws, depName)
+	if err != nil {
+		return nil, err
+	}
+	var generated hyrum.GenerateResult
+	if err := result.Decode(&generated); err != nil {
+		return nil, fmt.Errorf("decode tests.json: %w", err)
+	}
+	return &generationExecution{
+		Result: result, Generate: generated, TotalCost: cost, RecoveredSteps: recovered,
+	}, nil
+}
+
+func (p *pipeline) batchingEnabled() bool {
+	return p.batchSize > 0 || p.batchSites > 0
+}
+
 var transientWorkspaceFiles = []string{
 	"dep-outline.md",
 	"git-log.txt",
@@ -433,12 +517,19 @@ var transientWorkspaceFiles = []string{
 	"schema.json",
 }
 
+var transientWorkspaceDirs = []string{"batches"}
+
 func prepareWorkspace(ws string) error {
 	if err := os.MkdirAll(ws, 0o755); err != nil {
 		return err
 	}
 	for _, name := range transientWorkspaceFiles {
 		if err := os.Remove(filepath.Join(ws, name)); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale %s: %w", name, err)
+		}
+	}
+	for _, name := range transientWorkspaceDirs {
+		if err := os.RemoveAll(filepath.Join(ws, name)); err != nil {
 			return fmt.Errorf("remove stale %s: %w", name, err)
 		}
 	}
@@ -458,17 +549,14 @@ func (p *pipeline) runGenerateSkills(ctx context.Context, runner hyrum.Runner, w
 	var totalCost float64
 	var recoveredSteps []string
 	for _, s := range skillSteps {
-		fmt.Fprintf(os.Stderr, "  [%s]\n", s.name)
-		r, err := runner.RunSkill(ctx, p.h, ws, s.name, s.out, hyrum.RunOptions{Model: p.models[s.name], MaxTurns: s.maxTurns})
+		r, err := p.runGenerationStep(ctx, runner, ws, depName, s)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  %s/%s: %v\n", depName, s.name, err)
 			if s.required {
 				return nil, totalCost, recoveredSteps, err
 			}
 			continue
 		}
 		if r.BackendError != "" {
-			fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", depName, s.name, r.BackendError)
 			recoveredSteps = append(recoveredSteps, s.name)
 		}
 		totalCost += r.CostUSD
@@ -478,6 +566,26 @@ func (p *pipeline) runGenerateSkills(ctx context.Context, runner hyrum.Runner, w
 		return nil, totalCost, recoveredSteps, fmt.Errorf("generate produced no output")
 	}
 	return res, totalCost, recoveredSteps, nil
+}
+
+func (p *pipeline) runGenerationStep(
+	ctx context.Context,
+	runner hyrum.Runner,
+	ws, depName string,
+	step skillStep,
+) (*hyrum.RunResult, error) {
+	fmt.Fprintf(os.Stderr, "  [%s]\n", step.name)
+	result, err := runner.RunSkill(ctx, p.h, ws, step.name, step.out, hyrum.RunOptions{
+		Model: p.models[step.name], MaxTurns: step.maxTurns,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  %s/%s: %v\n", depName, step.name, err)
+		return nil, err
+	}
+	if result.BackendError != "" {
+		fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", depName, step.name, result.BackendError)
+	}
+	return result, nil
 }
 
 func generationMeta(targetDir string, d hyrum.Dep, res *hyrum.RunResult, gen hyrum.GenerateResult, totalCost float64) map[string]any {
@@ -668,6 +776,7 @@ func stageContext(
 	ws string,
 	rc *registries.Client,
 	usageOptions usage.IndexOptions,
+	symbols []string,
 ) (depDir, latest string, err error) {
 	if err := os.MkdirAll(ws, 0o755); err != nil {
 		return "", "", err
@@ -682,6 +791,10 @@ func stageContext(
 
 	// Usage surface (works even without the dep clone).
 	surf, err := usage.IndexWithOptions(ctx, t.Path, d.PURL, usageOptions)
+	if err != nil {
+		return "", "", fmt.Errorf("usage: %w", err)
+	}
+	surf, err = selectUsageSymbols(surf, symbols)
 	if err != nil {
 		return "", "", fmt.Errorf("usage: %w", err)
 	}

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -123,6 +123,14 @@ func TestPrepareWorkspaceRemovesTransientArtifacts(t *testing.T) {
 	if err := os.WriteFile(keep, nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
+	for _, name := range transientWorkspaceDirs {
+		if err := os.Mkdir(filepath.Join(ws, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(ws, name, "stale"), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	if err := prepareWorkspace(ws); err != nil {
 		t.Fatal(err)
@@ -130,6 +138,11 @@ func TestPrepareWorkspaceRemovesTransientArtifacts(t *testing.T) {
 	for _, name := range transientWorkspaceFiles {
 		if _, err := os.Stat(filepath.Join(ws, name)); !os.IsNotExist(err) {
 			t.Errorf("transient artifact %q remains: %v", name, err)
+		}
+	}
+	for _, name := range transientWorkspaceDirs {
+		if _, err := os.Stat(filepath.Join(ws, name)); !os.IsNotExist(err) {
+			t.Errorf("transient directory %q remains: %v", name, err)
 		}
 	}
 	if _, err := os.Stat(keep); err != nil {
@@ -380,6 +393,18 @@ func TestCmdGenRejectsFlagsAfterTarget(t *testing.T) {
 	err := cmdGen(context.Background(), []string{target, "--config", filepath.Join(t.TempDir(), "missing.yaml")})
 	if err == nil || !strings.Contains(err.Error(), "unexpected arguments after <path>") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCmdGenValidatesSymbolAndBatchSelectionBeforeAnalysis(t *testing.T) {
+	if err := cmdGen(t.Context(), []string{"--symbol", "Session", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--symbol requires exactly one --dep") {
+		t.Fatalf("symbol error = %v", err)
+	}
+	if err := cmdGen(t.Context(), []string{"--batch-size", "-1", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--batch-size must be zero or greater") {
+		t.Fatalf("batch error = %v", err)
+	}
+	if err := cmdGen(t.Context(), []string{"--batch-sites", "-1", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--batch-sites must be zero or greater") {
+		t.Fatalf("batch sites error = %v", err)
 	}
 }
 

--- a/cmd/hyrum/main.go
+++ b/cmd/hyrum/main.go
@@ -66,8 +66,8 @@ func printUsage() {
 const usageText = `hyrum: generate and run Hyrum's tests
 
 Usage:
-  hyrum surface [--config file] [--dep name] [--scope scope] [--include path] [--exclude path] [--json] [path]
-  hyrum gen     [--config file] [--dep name] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]
+  hyrum surface [--config file] [--dep name] [--symbol name] [--scope scope] [--include path] [--exclude path] [--json] [path]
+  hyrum gen     [--config file] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]
   hyrum check   --dep name[@version] [--tests dir] [path]
   hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N]
 

--- a/cmd/hyrum/main_test.go
+++ b/cmd/hyrum/main_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestUsageShowsAcceptedArgumentOrder(t *testing.T) {
 	for _, want := range []string{
-		"hyrum surface [--config file] [--dep name] [--scope scope] [--include path] [--exclude path] [--json] [path]",
-		"hyrum gen     [--config file] [--dep name] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]",
+		"hyrum surface [--config file] [--dep name] [--symbol name] [--scope scope] [--include path] [--exclude path] [--json] [path]",
+		"hyrum gen     [--config file] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]",
 		"hyrum check   --dep name[@version] [--tests dir] [path]",
 		"hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N]",
 	} {

--- a/cmd/hyrum/surface.go
+++ b/cmd/hyrum/surface.go
@@ -19,8 +19,9 @@ import (
 // the full symbol/site list for that dependency.
 func cmdSurface(ctx context.Context, args []string) error {
 	fs := newFlags("surface")
-	var deps, scopes, includes, excludes stringList
+	var deps, symbols, scopes, includes, excludes stringList
 	fs.Var(&deps, "dep", "dependency name to detail (repeatable); default: summarise all direct deps")
+	fs.Var(&symbols, "symbol", "exact dependency symbol to include (repeatable; requires one --dep)")
 	fs.Var(&scopes, "scope", "usage scope to include: production, test, example, or documentation (repeatable); default: all")
 	fs.Var(&includes, "include", "relative path prefix to include (repeatable)")
 	fs.Var(&excludes, "exclude", "relative path prefix to exclude (repeatable)")
@@ -29,6 +30,9 @@ func cmdSurface(ctx context.Context, args []string) error {
 	configPath := fs.String("config", "", "configuration file (default: <target>/hyrum.yaml when present)")
 	if err := fs.Parse(args); err != nil {
 		return err
+	}
+	if len(symbols) > 0 && len(deps) != 1 {
+		return fmt.Errorf("--symbol requires exactly one --dep")
 	}
 	set := visitedFlags(fs)
 	if set["config"] && *configPath == "" {
@@ -62,7 +66,7 @@ func cmdSurface(ctx context.Context, args []string) error {
 	if len(deps) == 0 {
 		return surfaceSummaryWithOptions(ctx, t, *directOnly, *asJSON, opts)
 	}
-	return surfaceDetailWithOptions(ctx, t, deps, *asJSON, opts)
+	return surfaceDetailWithOptions(ctx, t, deps, symbols, *asJSON, opts)
 }
 
 func surfaceSummaryWithOptions(
@@ -149,6 +153,7 @@ func surfaceDetailWithOptions(
 	ctx context.Context,
 	t *hyrum.Target,
 	names []string,
+	symbols []string,
 	asJSON bool,
 	opts usage.IndexOptions,
 ) error {
@@ -167,6 +172,10 @@ func surfaceDetailWithOptions(
 		}
 		if err != nil {
 			return err
+		}
+		s, err = selectUsageSymbols(s, symbols)
+		if err != nil {
+			return fmt.Errorf("%s: %w", d.Name, err)
 		}
 		out = append(out, s)
 	}

--- a/cmd/hyrum/surface_test.go
+++ b/cmd/hyrum/surface_test.go
@@ -110,3 +110,10 @@ func captureStdout(t *testing.T, run func() error) (string, error) {
 	}
 	return string(body), runErr
 }
+
+func TestSurfaceSymbolRequiresOneDependency(t *testing.T) {
+	err := cmdSurface(t.Context(), []string{"--symbol", "Session", t.TempDir()})
+	if err == nil || !strings.Contains(err.Error(), "--symbol requires exactly one --dep") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/cmd/hyrum/usage_options.go
+++ b/cmd/hyrum/usage_options.go
@@ -3,11 +3,23 @@ package main
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	hyrumconfig "github.com/alpha-omega-security/hyrum/internal/config"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
 )
+
+func selectUsageSymbols(surface *usage.Surface, names []string) (*usage.Surface, error) {
+	if len(names) == 0 {
+		return surface, nil
+	}
+	selected, missing := usage.SelectSymbols(surface, names)
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("usage symbols not found: %s", strings.Join(missing, ", "))
+	}
+	return selected, nil
+}
 
 func resolveUsageOptions(
 	scopes, includes, excludes stringList,

--- a/cmd/hyrum/usage_options_test.go
+++ b/cmd/hyrum/usage_options_test.go
@@ -76,3 +76,17 @@ func TestResolveUsageOptionsRejectsUnknownScopeAndUnsafePath(t *testing.T) {
 		t.Error("absolute exclude path accepted")
 	}
 }
+
+func TestSelectUsageSymbolsReturnsExactSortedMatches(t *testing.T) {
+	surface := &usage.Surface{Symbols: []usage.Symbol{{Name: "Session.get"}, {Name: "Session"}}}
+	selected, err := selectUsageSymbols(surface, []string{"Session.get"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(selected.Symbols) != 1 || selected.Symbols[0].Name != "Session.get" {
+		t.Fatalf("selected = %+v", selected.Symbols)
+	}
+	if _, err := selectUsageSymbols(surface, []string{"session.get"}); err == nil {
+		t.Fatal("case-mismatched symbol accepted")
+	}
+}

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,13 +1,12 @@
 # Model steps
 
-`hyrum gen --run` invokes four model-driven steps in sequence, each a
-[skill](../skills/) file (`SKILL.md` plus a JSON-schema output contract)
-staged into the workspace and run headlessly by the configured backend. The
-Go pipeline stages every non-model input first, so each step reads only
-files, and the output of each step is a JSON file the next one reads.
-Splitting the work this way keeps each prompt focused on one job, lets a
-cheaper model handle the extraction and classification steps while a stronger
-one writes tests, and makes each step's output inspectable in the workspace
+`hyrum gen --run` invokes the usage, history, and generation
+[skills](../skills/), followed by validation when `--verify` is set. Each skill
+is a `SKILL.md` file with a JSON-schema output contract, staged into the
+workspace and run headlessly by the configured backend. The Go pipeline stages
+every non-model input first, so each step reads files and leaves a JSON file for
+the next step. A cheaper model can handle extraction and classification while
+a stronger one writes tests, and every intermediate file remains available
 after a run.
 
 ## Workspace layout
@@ -24,6 +23,31 @@ Before any model step runs, `stageContext` and `GatherHistory` write:
 | `git-log.txt` | target commits selected by dependency mentions in messages or manifest diff excerpts | history |
 | `changelog.json` | `changelog.Between(baseline, latest)` from `dep/` (absent if none found) | history, validate |
 | `vulns.json` | osv.dev advisories for the dep's purl | history |
+| `batches/batch-NNN/usage.json` | one deterministic usage subset when a batch limit is set | inspection |
+
+## Symbol selection and batches
+
+Repeatable `--symbol` values select exact, case-sensitive names from
+`usage.json`. The flag requires one explicit dependency. Path selection still
+happens during indexing through `--include`, `--exclude`, and `--scope`, then
+symbol selection is applied to the resulting surface.
+
+`--batch-size N` caps symbol entries, and `--batch-sites N` caps static sites.
+Names and sites are sorted before partitioning. A symbol with more sites than
+the `--batch-sites` limit is split across batches so the cap still holds.
+History runs once and `breaks.json` is available to batch 1, which prevents
+every batch from generating the same history-derived tests. Usage and
+generation run for each group. Raw `usage.json`, `surface.json`, and
+`tests.json` files remain under `batches/batch-NNN/` for inspection.
+
+For runs with several batches, generated paths receive a `batch-NNN/` prefix
+before they are written under `tests/hyrum/<dep>/from_<target>/`. The driver
+merges static usage, traced calls, generation notes, and generated file lists;
+verification and validation then run once over that merged input. Top-level
+`meta.json` includes `batch_size` and `batch_sites` when their limits are set,
+plus `batch_count`, `history_cost_usd`, and a `batches` array. Each batch entry
+records its symbol names, site count, backend session, cost, notes, and any
+recovered model steps.
 
 ## hyrum-usage
 

--- a/internal/hyrum/usage/selection.go
+++ b/internal/hyrum/usage/selection.go
@@ -1,0 +1,133 @@
+package usage
+
+import "sort"
+
+// SelectSymbols returns a copy of surface containing exact symbol-name
+// matches. The result is sorted by name so repeated runs produce the same
+// ordering. Missing names are returned once in request order.
+func SelectSymbols(surface *Surface, names []string) (*Surface, []string) {
+	if surface == nil {
+		return nil, append([]string(nil), names...)
+	}
+	wanted := make(map[string]bool, len(names))
+	for _, name := range names {
+		wanted[name] = true
+	}
+	selected := make([]Symbol, 0, len(wanted))
+	for _, symbol := range surface.Symbols {
+		if wanted[symbol.Name] {
+			selected = append(selected, cloneSymbol(symbol))
+			delete(wanted, symbol.Name)
+		}
+	}
+	sort.Slice(selected, func(i, j int) bool { return selected[i].Name < selected[j].Name })
+
+	seenMissing := map[string]bool{}
+	var missing []string
+	for _, name := range names {
+		if wanted[name] && !seenMissing[name] {
+			seenMissing[name] = true
+			missing = append(missing, name)
+		}
+	}
+	return cloneSurfaceWithSymbols(surface, selected), missing
+}
+
+// PartitionSurface splits a surface by sorted symbol name and site order.
+// Positive limits cap the number of symbol entries and sites in each batch.
+// A symbol with more sites than the site limit is split across batches. An
+// empty surface still produces one batch for history-derived contracts.
+func PartitionSurface(surface *Surface, maxSymbols, maxSites int) []*Surface {
+	if surface == nil {
+		return nil
+	}
+	symbols := sortedSurfaceSymbols(surface.Symbols)
+	if maxSymbols <= 0 && maxSites <= 0 {
+		return []*Surface{cloneSurfaceWithSymbols(surface, symbols)}
+	}
+	batches := partitionSortedSymbols(surface, symbols, maxSymbols, maxSites)
+	if len(batches) == 0 {
+		return []*Surface{cloneSurfaceWithSymbols(surface, nil)}
+	}
+	return batches
+}
+
+func sortedSurfaceSymbols(source []Symbol) []Symbol {
+	symbols := make([]Symbol, len(source))
+	for i, symbol := range source {
+		symbols[i] = cloneSymbol(symbol)
+		sort.Slice(symbols[i].Sites, func(a, b int) bool {
+			left, right := symbols[i].Sites[a], symbols[i].Sites[b]
+			if left.File != right.File {
+				return left.File < right.File
+			}
+			if left.Line != right.Line {
+				return left.Line < right.Line
+			}
+			if left.Scope != right.Scope {
+				return left.Scope < right.Scope
+			}
+			return left.Context < right.Context
+		})
+	}
+	sort.Slice(symbols, func(i, j int) bool { return symbols[i].Name < symbols[j].Name })
+	return symbols
+}
+
+func partitionSortedSymbols(surface *Surface, symbols []Symbol, maxSymbols, maxSites int) []*Surface {
+	var batches []*Surface
+	var current []Symbol
+	currentSites := 0
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		batches = append(batches, cloneSurfaceWithSymbols(surface, current))
+		current = nil
+		currentSites = 0
+	}
+	for _, symbol := range symbols {
+		if len(symbol.Sites) == 0 {
+			if maxSymbols > 0 && len(current) >= maxSymbols {
+				flush()
+			}
+			current = append(current, symbol)
+			continue
+		}
+		remaining := symbol.Sites
+		for len(remaining) > 0 {
+			if batchLimitReached(len(current), currentSites, maxSymbols, maxSites) {
+				flush()
+			}
+			take := len(remaining)
+			if maxSites > 0 {
+				take = min(take, maxSites-currentSites)
+			}
+			fragment := symbol
+			fragment.Sites = append([]Site(nil), remaining[:take]...)
+			current = append(current, fragment)
+			currentSites += take
+			remaining = remaining[take:]
+		}
+	}
+	flush()
+	return batches
+}
+
+func batchLimitReached(symbols, sites, maxSymbols, maxSites int) bool {
+	return maxSymbols > 0 && symbols >= maxSymbols || maxSites > 0 && sites >= maxSites
+}
+
+func cloneSurfaceWithSymbols(surface *Surface, symbols []Symbol) *Surface {
+	clone := *surface
+	clone.Symbols = make([]Symbol, len(symbols))
+	for i, symbol := range symbols {
+		clone.Symbols[i] = cloneSymbol(symbol)
+	}
+	return &clone
+}
+
+func cloneSymbol(symbol Symbol) Symbol {
+	symbol.Sites = append([]Site(nil), symbol.Sites...)
+	return symbol
+}

--- a/internal/hyrum/usage/selection_test.go
+++ b/internal/hyrum/usage/selection_test.go
@@ -1,0 +1,100 @@
+package usage
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSelectSymbolsUsesExactNamesAndReportsMissing(t *testing.T) {
+	surface := &Surface{
+		Dep: "dep",
+		Symbols: []Symbol{
+			{Name: "zeta", Sites: []Site{{File: "z.go", Line: 3}}},
+			{Name: "alpha", Sites: []Site{{File: "a.go", Line: 1}}},
+			{Name: "alpha.member", Sites: []Site{{File: "a.go", Line: 2}}},
+		},
+	}
+	selected, missing := SelectSymbols(surface, []string{"alpha.member", "alpha", "absent", "absent"})
+	if got := surfaceSymbolNames(selected); !reflect.DeepEqual(got, []string{"alpha", "alpha.member"}) {
+		t.Fatalf("selected symbols = %v", got)
+	}
+	if !reflect.DeepEqual(missing, []string{"absent"}) {
+		t.Fatalf("missing symbols = %v", missing)
+	}
+	if len(surface.Symbols) != 3 || surface.Symbols[0].Name != "zeta" {
+		t.Fatalf("source surface changed: %+v", surface.Symbols)
+	}
+}
+
+func TestPartitionSymbolsIsStableAndCopiesSites(t *testing.T) {
+	surface := &Surface{Symbols: []Symbol{
+		{Name: "zeta", Sites: []Site{{File: "z.go"}}},
+		{Name: "alpha", Sites: []Site{{File: "a.go"}}},
+		{Name: "middle", Sites: []Site{{File: "m.go"}}},
+	}}
+	batches := PartitionSurface(surface, 2, 0)
+	if len(batches) != 2 {
+		t.Fatalf("batches = %d", len(batches))
+	}
+	if got := surfaceSymbolNames(batches[0]); !reflect.DeepEqual(got, []string{"alpha", "middle"}) {
+		t.Errorf("batch 1 = %v", got)
+	}
+	if got := surfaceSymbolNames(batches[1]); !reflect.DeepEqual(got, []string{"zeta"}) {
+		t.Errorf("batch 2 = %v", got)
+	}
+	batches[0].Symbols[0].Sites[0].File = "changed.go"
+	if surface.Symbols[1].Sites[0].File != "a.go" {
+		t.Fatalf("partition shares site storage with source: %+v", surface.Symbols)
+	}
+}
+
+func TestPartitionSymbolsKeepsOneEmptyBatch(t *testing.T) {
+	batches := PartitionSurface(&Surface{Dep: "dep"}, 10, 0)
+	if len(batches) != 1 || batches[0].Dep != "dep" || len(batches[0].Symbols) != 0 {
+		t.Fatalf("empty batches = %+v", batches)
+	}
+}
+
+func TestPartitionSurfaceSplitsLargeSymbolBySites(t *testing.T) {
+	surface := &Surface{Symbols: []Symbol{
+		{Name: "small", Sites: []Site{{File: "b.go", Line: 2}}},
+		{Name: "large", Sites: []Site{
+			{File: "c.go", Line: 3},
+			{File: "a.go", Line: 1},
+			{File: "b.go", Line: 2},
+			{File: "d.go", Line: 4},
+		}},
+	}}
+	batches := PartitionSurface(surface, 2, 3)
+	if len(batches) != 2 {
+		t.Fatalf("batches = %+v", batches)
+	}
+	if got := len(batches[0].Symbols[0].Sites); got != 3 || batches[0].Symbols[0].Name != "large" {
+		t.Fatalf("batch 1 = %+v", batches[0].Symbols)
+	}
+	if batches[0].Symbols[0].Sites[0].File != "a.go" {
+		t.Fatalf("sites are not sorted: %+v", batches[0].Symbols[0].Sites)
+	}
+	if got := surfaceSiteCount(batches[1]); got != 2 {
+		t.Fatalf("batch 2 sites = %d, want 2: %+v", got, batches[1].Symbols)
+	}
+	if batches[1].Symbols[0].Name != "large" || batches[1].Symbols[1].Name != "small" {
+		t.Fatalf("split symbol order = %+v", batches[1].Symbols)
+	}
+}
+
+func surfaceSymbolNames(surface *Surface) []string {
+	names := make([]string, 0, len(surface.Symbols))
+	for _, symbol := range surface.Symbols {
+		names = append(names, symbol.Name)
+	}
+	return names
+}
+
+func surfaceSiteCount(surface *Surface) int {
+	count := 0
+	for _, symbol := range surface.Symbols {
+		count += len(symbol.Sites)
+	}
+	return count
+}

--- a/skills/hyrum-generate/SKILL.md
+++ b/skills/hyrum-generate/SKILL.md
@@ -19,7 +19,7 @@ Your working directory is the workspace root. Every path below is relative to it
 - `target/` — the repository whose usage you are capturing (read-only)
 - `dep/` — clone of the dependency's source (read-only, may be absent)
 - `dep-outline.md` — signature-only outline of the dependency's public surface at the baseline version
-- `usage.json` — static entry points: which symbols `target/` imports and where
+- `usage.json`: static entry points showing which symbols `target/` imports and where. With batching, this contains the current name-sorted symbol subset.
 - `surface.json` — traced calls on values derived from those entry points (may be absent)
 - `breaks.json` — past compatibility fixes mined from git history and changelog (may be absent)
 - `context.json` — `{purl, name, ecosystem, version, repo, latest, target}`

--- a/skills/hyrum-usage/SKILL.md
+++ b/skills/hyrum-usage/SKILL.md
@@ -18,7 +18,7 @@ Your working directory is the workspace root. Every path below is relative to it
 
 - `target/` — the repository whose usage you are tracing (read-only)
 - `dep-outline.md` — signature-only outline of the dependency's public surface
-- `usage.json`: static entry points: `{symbols: [{name, kind, sites: [{file, line, context, scope}]}]}`
+- `usage.json`: static entry points in the form `{symbols: [{name, kind, sites: [{file, line, context, scope}]}]}`. With batching, this contains the current name-sorted symbol subset.
 - `context.json` — `{purl, name, ecosystem, version, repo, latest, target}`
 - `surface.json` — write your output here per `schema.json`
 


### PR DESCRIPTION
Add exact symbol selection and deterministic generation batches bounded by symbols or usage sites. Merge batch outputs and retain batch-level metadata in the generated suite.