### PR TITLE
Distinguish subdirectory target identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ writes the same layout under its required `--out` directory, so the same suite
 can serve both the consumer and the dependency's maintainer. Worked examples
 with real command output are in [docs/](docs/).
 
+`<target>` uses the package name declared by one root manifest when that name
+is unambiguous. A target below the Git root adds a stable suffix derived from
+its repository-relative path, so repeated package names remain separate.
+Targets without one package name use the repository name and relative path.
+`gen --target-name` and the `target_name` config setting provide an explicit
+one-component name. Automatic names that require normalization receive a
+suffix hash so distinct source identities remain distinct.
+
 **Consumer CI** ([docs/consumer-ci.md](docs/consumer-ci.md)). Run
 `tests/hyrum/<dep>/` on the [dependabot](https://docs.github.com/en/code-security/dependabot)
 or [renovate](https://docs.renovatebot.com) PR that bumps `<dep>`; a
@@ -145,12 +153,12 @@ unreadable, malformed, or invalid explicit file is an error, while an absent
 automatic file is not. Configuration is strict: unknown keys and incorrect
 value types are rejected.
 
-The supported settings are `backend`, `out`, `work`, per-skill `models`, and
-per-dependency `baseline`, `skip`, and `activations` values under `deps`.
-Explicit command-line flags take precedence over config, and config takes
-precedence over built-in defaults. Relative `out` paths are rooted at the
-target repository. For safety, `out` in an automatically discovered target
-configuration must remain inside that target; an explicitly supplied
+The supported settings are `backend`, `out`, `work`, `target_name`, per-skill
+`models`, and per-dependency `baseline`, `skip`, and `activations` values under
+`deps`. Explicit command-line flags take precedence over config, and config
+takes precedence over built-in defaults. Relative `out` paths are rooted at
+the target repository. For safety, `out` in an automatically discovered
+target configuration must remain inside that target; an explicitly supplied
 `--config` may select an external output path.
 
 An automatically discovered config cannot select `work`: that value is ignored
@@ -216,6 +224,7 @@ hyrum surface --dep X <path>          symbol-level detail for one dep
 hyrum surface --dep X --symbol X.y ... inspect selected exact symbols
 hyrum surface --scope test <path>     restrict the summary to test usage
 hyrum gen --dep X --run <path>        generate tests for X into tests/hyrum/
+hyrum gen --dep X --target-name app ... override the generated target identity
 hyrum gen --dep X --batch-size 40 ... cap each model batch at 40 symbols
 hyrum gen --dep X --batch-sites 500 ... cap each model batch at 500 sites
 hyrum gen --dep X --outline-bytes 131072 ... set the source outline limit

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -61,6 +61,7 @@ type genOptions struct {
 	backend      string
 	out          string
 	work         string
+	targetName   string
 	outlineBytes int
 	models       map[string]string
 }
@@ -95,6 +96,7 @@ func cmdGen(ctx context.Context, args []string) error {
 	batchSize := fs.Int("batch-size", 0, "maximum symbol entries per model batch; zero disables this limit")
 	batchSites := fs.Int("batch-sites", 0, "maximum static sites per model batch; zero disables this limit")
 	outlineBytes := fs.Int("outline-bytes", defaults.outlineBytes, "maximum bytes in each dependency outline")
+	targetNameOverride := fs.String("target-name", "", "stable name used in work and output paths (default: package or repository identity)")
 	container := fs.String("container", "", "run the backend in a container using this image (\"default\" for "+hyrum.DefaultRunnerImage+")")
 	verify := fs.Bool("verify", false, "after generating, run the tests against the baseline and latest dep versions and record results in meta.json")
 	if err := fs.Parse(args); err != nil {
@@ -115,6 +117,12 @@ func cmdGen(ctx context.Context, args []string) error {
 	if *outlineBytes <= 0 {
 		return fmt.Errorf("--outline-bytes must be greater than zero")
 	}
+	set := visitedFlags(fs)
+	if set["target-name"] {
+		if err := validateTargetName(*targetNameOverride); err != nil {
+			return err
+		}
+	}
 	usageOptions, err := resolveUsageOptions(scopes, includes, excludes, []usage.Scope{usage.ScopeProduction})
 	if err != nil {
 		return err
@@ -129,7 +137,6 @@ func cmdGen(ctx context.Context, args []string) error {
 		return err
 	}
 
-	set := visitedFlags(fs)
 	if set["config"] && *configPath == "" {
 		return fmt.Errorf("--config requires a non-empty path")
 	}
@@ -141,6 +148,7 @@ func cmdGen(ctx context.Context, args []string) error {
 		backend:      *backend,
 		out:          *out,
 		work:         *work,
+		targetName:   *targetNameOverride,
 		outlineBytes: *outlineBytes,
 	}, set)
 	if err != nil {
@@ -170,6 +178,7 @@ func cmdGen(ctx context.Context, args []string) error {
 	p.batchSize = *batchSize
 	p.batchSites = *batchSites
 	p.outlineBytes = resolved.outlineBytes
+	p.targetName = resolved.targetName
 	return p.genAll(ctx, t, selected)
 }
 
@@ -201,6 +210,9 @@ func resolveGenOptions(targetRoot, configPath string, explicitConfig bool, cfg h
 	if cfg.OutlineBytes != nil {
 		resolved.outlineBytes = *cfg.OutlineBytes
 	}
+	if cfg.TargetName != nil {
+		resolved.targetName = *cfg.TargetName
+	}
 	resolved.models = cfg.Models
 
 	if set["backend"] {
@@ -222,6 +234,14 @@ func resolveGenOptions(targetRoot, configPath string, explicitConfig bool, cfg h
 	}
 	if set["outline-bytes"] {
 		resolved.outlineBytes = cli.outlineBytes
+	}
+	if set["target-name"] {
+		resolved.targetName = cli.targetName
+	}
+	if resolved.targetName != "" {
+		if err := validateTargetName(resolved.targetName); err != nil {
+			return genOptions{}, err
+		}
 	}
 	trustedExternalOut := set["out"] || (explicitConfig && cfg.Out != nil)
 	if !trustedExternalOut && !pathWithinResolved(targetRoot, resolved.out) {
@@ -331,6 +351,9 @@ type pipeline struct {
 	batchSites int
 	// outlineBytes caps the rendered dependency outline passed to model steps.
 	outlineBytes int
+	// targetName overrides the identity detected from the target manifest or
+	// repository path.
+	targetName string
 	// models maps skill names to backend-owned model IDs resolved from the
 	// portable mid/high/max tiers in hyrum.yaml.
 	models map[string]string
@@ -409,7 +432,10 @@ func (p *pipeline) genAll(ctx context.Context, t *hyrum.Target, deps []hyrum.Dep
 
 func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.HistoryIndex, d hyrum.Dep) error {
 	targetDir := targetName(t)
-	if err := validateRelativePath("target name", targetDir); err != nil {
+	if p.targetName != "" {
+		targetDir = p.targetName
+	}
+	if err := validateTargetName(targetDir); err != nil {
 		return err
 	}
 	if err := validateRelativePath("ecosystem", d.Ecosystem); err != nil {
@@ -771,12 +797,25 @@ func validateRelativePath(label, value string) error {
 	return nil
 }
 
+func validateTargetName(value string) error {
+	if err := validateRelativePath("target name", value); err != nil {
+		return err
+	}
+	if filepath.Base(value) != value || strings.ContainsAny(value, `/\\`) {
+		return fmt.Errorf("unsafe target name %q: must be one path component", value)
+	}
+	return nil
+}
+
 // targetName is the from_<x> directory component. Prefers the basename of the
 // origin remote, then any https remote, then the path basename. brief's
 // Remotes is a map so plain iteration would pick a deploy remote (dokku,
 // heroku) at random.
 func targetName(t *hyrum.Target) string {
-	if t.Report.Git != nil {
+	if t.Name != "" {
+		return t.Name
+	}
+	if t.Report != nil && t.Report.Git != nil {
 		remotes := t.Report.Git.Remotes
 		if u := remotes["origin"]; u != "" {
 			return remoteBasename(u)

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -233,9 +233,9 @@ func TestResolveGenOptionsPrecedence(t *testing.T) {
 	configDir := t.TempDir()
 	configPath := filepath.Join(configDir, "hyrum.yaml")
 	target := t.TempDir()
-	backend, configOut, configWork := "codex", "configured/out", "configured/work"
+	backend, configOut, configWork, configTargetName := "codex", "configured/out", "configured/work", "configured-target"
 	configOutlineBytes := 131072
-	cfg := hyrumconfig.File{Backend: &backend, Out: &configOut, Work: &configWork, OutlineBytes: &configOutlineBytes}
+	cfg := hyrumconfig.File{Backend: &backend, Out: &configOut, Work: &configWork, TargetName: &configTargetName, OutlineBytes: &configOutlineBytes}
 
 	t.Run("discovered config cannot set work", func(t *testing.T) {
 		got, err := resolveGenOptions(target, configPath, false, cfg, defaultGenOptions(), nil)
@@ -254,6 +254,9 @@ func TestResolveGenOptionsPrecedence(t *testing.T) {
 		if got.outlineBytes != configOutlineBytes {
 			t.Errorf("outline bytes = %d", got.outlineBytes)
 		}
+		if got.targetName != configTargetName {
+			t.Errorf("target name = %q", got.targetName)
+		}
 	})
 
 	t.Run("explicit config can set work", func(t *testing.T) {
@@ -271,16 +274,25 @@ func TestResolveGenOptionsPrecedence(t *testing.T) {
 		cli.backend = "claude" // Deliberately equal to the built-in default.
 		cli.out = "cli/out"
 		cli.work = "cli/work"
+		cli.targetName = "cli-target"
 		cli.outlineBytes = 65536
-		set := map[string]bool{"backend": true, "out": true, "work": true, "outline-bytes": true}
+		set := map[string]bool{"backend": true, "out": true, "work": true, "target-name": true, "outline-bytes": true}
 		got, err := resolveGenOptions(target, configPath, false, cfg, cli, set)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got.backend != "claude" || got.out != filepath.Join(target, "cli/out") || got.work != "cli/work" || got.outlineBytes != 65536 {
+		if got.backend != "claude" || got.out != filepath.Join(target, "cli/out") || got.work != "cli/work" || got.targetName != "cli-target" || got.outlineBytes != 65536 {
 			t.Fatalf("resolved = %+v", got)
 		}
 	})
+}
+
+func TestResolveGenOptionsRejectsUnsafeTargetName(t *testing.T) {
+	targetName := "scope/package"
+	_, err := resolveGenOptions(t.TempDir(), "", false, hyrumconfig.File{TargetName: &targetName}, defaultGenOptions(), nil)
+	if err == nil || !strings.Contains(err.Error(), "must be one path component") {
+		t.Fatalf("error = %v, want target-name component error", err)
+	}
 }
 
 func TestResolveGenOptionsExpandsConfiguredOutFromTarget(t *testing.T) {
@@ -415,6 +427,9 @@ func TestCmdGenValidatesSymbolAndBatchSelectionBeforeAnalysis(t *testing.T) {
 	}
 	if err := cmdGen(t.Context(), []string{"--batch-size", "-1", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--batch-size must be zero or greater") {
 		t.Fatalf("batch error = %v", err)
+	}
+	if err := cmdGen(t.Context(), []string{"--target-name", "scope/package", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "must be one path component") {
+		t.Fatalf("target name error = %v", err)
 	}
 	if err := cmdGen(t.Context(), []string{"--batch-sites", "-1", t.TempDir()}); err == nil || !strings.Contains(err.Error(), "--batch-sites must be zero or greater") {
 		t.Fatalf("batch sites error = %v", err)

--- a/cmd/hyrum/helpers_test.go
+++ b/cmd/hyrum/helpers_test.go
@@ -90,6 +90,32 @@ func TestTargetNamePrefersOrigin(t *testing.T) {
 	}
 }
 
+func TestTargetNamePrefersAnalyzedPackageIdentity(t *testing.T) {
+	tgt := &hyrum.Target{
+		Path: "/tmp/airflow-core",
+		Name: "apache-airflow-core",
+		Report: &brief.Report{Git: &brief.GitInfo{Remotes: map[string]string{
+			"origin": "https://github.com/apache/airflow.git",
+		}}},
+	}
+	if got := targetName(tgt); got != "apache-airflow-core" {
+		t.Fatalf("got %q, want apache-airflow-core", got)
+	}
+}
+
+func TestValidateTargetName(t *testing.T) {
+	for _, value := range []string{"airflow", "apache-airflow-core", "project.name_v2"} {
+		if err := validateTargetName(value); err != nil {
+			t.Errorf("validateTargetName(%q): %v", value, err)
+		}
+	}
+	for _, value := range []string{"", ".", "..", "../escape", "scope/package", `scope\package`} {
+		if err := validateTargetName(value); err == nil {
+			t.Errorf("validateTargetName(%q) succeeded", value)
+		}
+	}
+}
+
 func TestSlugify(t *testing.T) {
 	cases := map[string]string{
 		"https://github.com/a/b":  "github_com_a_b",

--- a/cmd/hyrum/main.go
+++ b/cmd/hyrum/main.go
@@ -67,7 +67,7 @@ const usageText = `hyrum: generate and run Hyrum's tests
 
 Usage:
   hyrum surface [--config file] [--dep name] [--symbol name] [--scope scope] [--include path] [--exclude path] [--json] [path]
-  hyrum gen     [--config file] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--outline-bytes N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]
+  hyrum gen     [--config file] [--target-name name] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--outline-bytes N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]
   hyrum check   --dep name[@version] [--tests dir] [path]
   hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N] [--outline-bytes N]
 

--- a/cmd/hyrum/main_test.go
+++ b/cmd/hyrum/main_test.go
@@ -8,7 +8,7 @@ import (
 func TestUsageShowsAcceptedArgumentOrder(t *testing.T) {
 	for _, want := range []string{
 		"hyrum surface [--config file] [--dep name] [--symbol name] [--scope scope] [--include path] [--exclude path] [--json] [path]",
-		"hyrum gen     [--config file] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--outline-bytes N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]",
+		"hyrum gen     [--config file] [--target-name name] [--dep name] [--symbol name] [--batch-size N] [--batch-sites N] [--outline-bytes N] [--scope scope] [--include path] [--exclude path] [--out dir] [--work dir] [--backend name] [--run] [path]",
 		"hyrum check   --dep name[@version] [--tests dir] [path]",
 		"hyrum corpus  --upstream purl --out dir [--dependent URL[@ref]] [--discover N] [--outline-bytes N]",
 	} {

--- a/docs/consumer-ci.md
+++ b/docs/consumer-ci.md
@@ -17,8 +17,12 @@ git commit -m "Add Hyrum's tests for ws"
 ```
 
 The generated files are plain `node:test` (or pytest, or `go test`) files
-under `tests/hyrum/<dep>/from_<repo>/` with a `meta.json` recording the
-baseline version and generation inputs.
+under `tests/hyrum/<dep>/from_<target>/` with a `meta.json` recording the
+baseline version and generation inputs. The target component uses the package
+name from one root manifest when available. Nested targets add a stable suffix
+from their Git-relative path, so repeated package names keep separate suites.
+`gen --target-name <name>` can
+set it explicitly.
 
 If a backend exits non-zero after writing a fresh, usable output artifact,
 Hyrum preserves that output and records `recovered_output: true` plus the

--- a/docs/producer-corpus.md
+++ b/docs/producer-corpus.md
@@ -16,8 +16,11 @@ hyrum corpus --upstream ws --out ./corpus --backend codex --run \
 ```
 
 Each `--dependent` is cloned, its usage of `ws` is extracted, and a test file
-is written under `./corpus/ws/from_<dependent>/`. The `@ref` suffix pins a
-dependent that has moved or been archived. Dependents can also be listed in a
+is written under `./corpus/ws/from_<dependent>/`. The dependent component uses
+one root manifest's package name. Nested targets add a suffix derived from the
+Git-relative path; targets without one package name use the repository name and
+relative path. The `@ref` suffix pins a dependent
+that has moved or been archived. Dependents can also be listed in a
 `downstream.toml` written by
 [downstream discover](https://github.com/git-pkgs/downstream), which queries
 [ecosyste.ms](https://ecosyste.ms) for the most-used packages depending on

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -66,6 +66,12 @@ plus `batch_count`, `history_cost_usd`, and a `batches` array. Each batch entry
 records its symbol names, site count, backend session, cost, notes, and any
 recovered model steps.
 
+The target path component uses one package name declared by a root manifest.
+Nested targets add a stable suffix derived from their Git-relative path. If the
+target has no single package name, it uses the repository name and relative
+path. `gen --target-name` and `target_name` in `hyrum.yaml` override the
+detected value.
+
 ## hyrum-usage
 
 Reads `usage.json`, `target/`, `dep-outline.md`, `outline-selection.json`, and

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/git-pkgs/dependents v0.1.0
 	github.com/git-pkgs/enrichment v0.7.0
 	github.com/git-pkgs/managers v0.10.1
+	github.com/git-pkgs/manifests v0.10.0
 	github.com/git-pkgs/outline v0.2.1
 	github.com/git-pkgs/provides v0.2.0
 	github.com/git-pkgs/purl v0.1.17
@@ -30,7 +31,6 @@ require (
 	github.com/git-pkgs/gitignore v1.2.0 // indirect
 	github.com/git-pkgs/licensecheck v0.4.1 // indirect
 	github.com/git-pkgs/magic v0.2.0 // indirect
-	github.com/git-pkgs/manifests v0.10.0 // indirect
 	github.com/git-pkgs/packageurl-go v0.3.1 // indirect
 	github.com/git-pkgs/pom v0.1.7 // indirect
 	github.com/git-pkgs/spdx v0.3.1 // indirect

--- a/hyrum.sample.yaml
+++ b/hyrum.sample.yaml
@@ -21,6 +21,13 @@
 # --config files may also use absolute paths and paths beginning with ~/.
 # out: tests/hyrum
 
+# Name used below the work root and in tests/hyrum/<dependency>/from_<name>.
+# Hyrum normally reads one package name from the target's root manifest. Nested
+# targets add a suffix derived from their Git-relative path. The fallback is the
+# repository name plus that path. An explicit value must contain one path
+# component. `gen --target-name` wins.
+# target_name: apache-airflow-core
+
 # Working directory for dependency clones and skill workspaces. This setting is
 # ignored when the config is auto-discovered; pass --config explicitly to trust
 # it. Relative paths use the directory containing that explicit config file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type File struct {
 	Models       map[string]string     `yaml:"models,omitempty"`
 	Out          *string               `yaml:"out,omitempty"`
 	Work         *string               `yaml:"work,omitempty"`
+	TargetName   *string               `yaml:"target_name,omitempty"`
 	OutlineBytes *int                  `yaml:"outline_bytes,omitempty"`
 	Deps         map[string]Dependency `yaml:"deps,omitempty"`
 }
@@ -128,9 +129,10 @@ func Parse(data []byte) (File, error) {
 
 func (cfg File) validate() error {
 	for name, value := range map[string]*string{
-		"backend": cfg.Backend,
-		"out":     cfg.Out,
-		"work":    cfg.Work,
+		"backend":     cfg.Backend,
+		"out":         cfg.Out,
+		"work":        cfg.Work,
+		"target_name": cfg.TargetName,
 	} {
 		if value != nil && strings.TrimSpace(*value) == "" {
 			return fmt.Errorf("%s must not be empty", name)
@@ -192,7 +194,7 @@ func validateNodeTypes(root *yaml.Node) error {
 			return fmt.Errorf("configuration keys must be strings (line %d)", key.Line)
 		}
 		switch key.Value {
-		case "backend", "out", "work":
+		case "backend", "out", "work", "target_name":
 			if err := requireTag(key.Value, value, yamlStringTag); err != nil {
 				return err
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -14,6 +14,7 @@ func TestLoadExplicitConfig(t *testing.T) {
 backend: codex
 out: generated/hyrum
 work: workspaces
+target_name: airflow-core
 outline_bytes: 131072
 models:
   hyrum-generate: high
@@ -40,6 +41,9 @@ deps:
 	}
 	if cfg.OutlineBytes == nil || *cfg.OutlineBytes != 131072 {
 		t.Fatalf("outline_bytes = %v", cfg.OutlineBytes)
+	}
+	if cfg.TargetName == nil || *cfg.TargetName != "airflow-core" {
+		t.Fatalf("target_name = %v", cfg.TargetName)
 	}
 	dep := cfg.Deps["ws"]
 	if dep.Baseline == nil || *dep.Baseline != "8.17.1" {
@@ -98,19 +102,21 @@ func TestLoadUnreadableExplicitConfigFails(t *testing.T) {
 
 func TestParseRejectsMalformedUnknownAndIncorrectTypes(t *testing.T) {
 	tests := map[string]string{
-		"malformed":        "backend: [\n",
-		"unknown top key":  "backed: codex\n",
-		"unknown dep key":  "deps:\n  ws:\n    basline: 1.0\n",
-		"backend type":     "backend: true\n",
-		"skip type":        "deps:\n  ws:\n    skip: yes-please\n",
-		"activations type": "deps:\n  ws:\n    activations: ws-driver\n",
-		"activation type":  "deps:\n  ws:\n    activations: [true]\n",
-		"empty activation": "deps:\n  ws:\n    activations: ['']\n",
-		"null":             "work: null\n",
-		"outline type":     "outline_bytes: large\n",
-		"outline zero":     "outline_bytes: 0\n",
-		"outline negative": "outline_bytes: -1\n",
-		"second document":  "backend: codex\n---\nbackend: claude\n",
+		"malformed":         "backend: [\n",
+		"unknown top key":   "backed: codex\n",
+		"unknown dep key":   "deps:\n  ws:\n    basline: 1.0\n",
+		"backend type":      "backend: true\n",
+		"skip type":         "deps:\n  ws:\n    skip: yes-please\n",
+		"activations type":  "deps:\n  ws:\n    activations: ws-driver\n",
+		"activation type":   "deps:\n  ws:\n    activations: [true]\n",
+		"empty activation":  "deps:\n  ws:\n    activations: ['']\n",
+		"null":              "work: null\n",
+		"empty target name": "target_name: ''\n",
+		"target name type":  "target_name: true\n",
+		"outline type":      "outline_bytes: large\n",
+		"outline zero":      "outline_bytes: 0\n",
+		"outline negative":  "outline_bytes: -1\n",
+		"second document":   "backend: codex\n---\nbackend: claude\n",
 	}
 	for name, body := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/hyrum/target.go
+++ b/internal/hyrum/target.go
@@ -4,12 +4,17 @@
 package hyrum
 
 import (
+	"crypto/sha256"
 	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/git-pkgs/brief"
 	"github.com/git-pkgs/brief/detect"
 	"github.com/git-pkgs/brief/kb"
+	"github.com/git-pkgs/manifests"
 	"github.com/git-pkgs/purl"
 )
 
@@ -17,6 +22,7 @@ import (
 // discovered about it that later pipeline stages need.
 type Target struct {
 	Path   string
+	Name   string
 	Report *brief.Report
 	Deps   []Dep
 }
@@ -64,7 +70,158 @@ func Analyze(path string) (*Target, error) {
 		})
 	}
 
-	return &Target{Path: abs, Report: rep, Deps: deps}, nil
+	return &Target{Path: abs, Name: detectTargetName(abs, rep), Report: rep, Deps: deps}, nil
+}
+
+// detectTargetName returns one stable directory component for a target.
+// Nested package targets include their Git-relative path in the identity.
+func detectTargetName(targetPath string, report *brief.Report) string {
+	repositoryRoot := findRepositoryRoot(targetPath)
+	relativePath := repositoryRelativeTargetPath(repositoryRoot, targetPath)
+	if name := manifestPackageName(targetPath); name != "" {
+		if relativePath != "" {
+			return normalizeTargetName(name) + "-" + targetNameHash(relativePath)
+		}
+		return normalizeTargetName(name)
+	}
+
+	name := reportRemoteName(report)
+	if name == "" {
+		if repositoryRoot != "" {
+			name = filepath.Base(repositoryRoot)
+		} else {
+			name = filepath.Base(targetPath)
+		}
+	}
+	if relativePath != "" {
+		name += "/" + relativePath
+	}
+	return normalizeTargetName(name)
+}
+
+func repositoryRelativeTargetPath(repositoryRoot, targetPath string) string {
+	if repositoryRoot == "" {
+		return ""
+	}
+	relative, err := filepath.Rel(repositoryRoot, targetPath)
+	if err != nil || relative == "." {
+		return ""
+	}
+	return filepath.ToSlash(relative)
+}
+
+// manifestPackageName returns a package name only when the target has one
+// unambiguous root manifest identity. Nested workspace members describe other
+// packages and do not name the selected target directory.
+func manifestPackageName(targetPath string) string {
+	entries, err := os.ReadDir(targetPath)
+	if err != nil {
+		return ""
+	}
+	names := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.IsDir() || entry.Type()&os.ModeSymlink != 0 {
+			continue
+		}
+		_, kind, ok := manifests.Identify(entry.Name())
+		if !ok || kind != manifests.Manifest {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(targetPath, entry.Name()))
+		if err != nil {
+			continue
+		}
+		parsed, err := manifests.Parse(entry.Name(), content, manifests.Options{FSRoot: targetPath})
+		if err != nil {
+			continue
+		}
+		if name := strings.TrimSpace(parsed.Name); name != "" {
+			names[name] = struct{}{}
+		}
+	}
+	if len(names) != 1 {
+		return ""
+	}
+	for name := range names {
+		return name
+	}
+	return ""
+}
+
+func reportRemoteName(report *brief.Report) string {
+	if report == nil || report.Git == nil {
+		return ""
+	}
+	if remote := report.Git.Remotes["origin"]; remote != "" {
+		return remoteBase(remote)
+	}
+	var remotes []string
+	for _, remote := range report.Git.Remotes {
+		if strings.HasPrefix(remote, "https://") {
+			remotes = append(remotes, remote)
+		}
+	}
+	sort.Strings(remotes)
+	if len(remotes) == 0 {
+		return ""
+	}
+	return remoteBase(remotes[0])
+}
+
+func remoteBase(remote string) string {
+	base := filepath.Base(remote)
+	return strings.TrimSuffix(base, ".git")
+}
+
+func findRepositoryRoot(targetPath string) string {
+	current := filepath.Clean(targetPath)
+	for {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			return ""
+		}
+		current = parent
+	}
+}
+
+// normalizeTargetName converts package names and Git-relative fallback paths
+// into one portable path component. A hash preserves identity when case or
+// punctuation is changed during normalization.
+func normalizeTargetName(value string) string {
+	original := strings.TrimSpace(value)
+	var normalized strings.Builder
+	separator := false
+	for _, char := range original {
+		switch {
+		case char >= 'A' && char <= 'Z':
+			normalized.WriteRune(char + ('a' - 'A'))
+			separator = false
+		case char >= 'a' && char <= 'z', char >= '0' && char <= '9', char == '-', char == '_', char == '.':
+			normalized.WriteRune(char)
+			separator = false
+		default:
+			if normalized.Len() > 0 && !separator {
+				normalized.WriteByte('-')
+				separator = true
+			}
+		}
+	}
+	name := strings.Trim(normalized.String(), "-._")
+	if name == "" {
+		name = "target"
+	}
+	if name == original {
+		return name
+	}
+	return name + "-" + targetNameHash(original)
+}
+
+func targetNameHash(value string) string {
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(value)))
+	return hash[:10]
 }
 
 func ecosystemOf(p string) string {

--- a/internal/hyrum/target_test.go
+++ b/internal/hyrum/target_test.go
@@ -1,0 +1,122 @@
+package hyrum
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-pkgs/brief"
+)
+
+func TestDetectTargetNameUsesRootManifestPackageName(t *testing.T) {
+	targetPath := t.TempDir()
+	writeTargetFile(t, filepath.Join(targetPath, "pyproject.toml"), "[project]\nname = \"apache-airflow-core\"\n")
+	report := &brief.Report{Git: &brief.GitInfo{Remotes: map[string]string{
+		"origin": "https://github.com/apache/airflow.git",
+	}}}
+
+	if got := detectTargetName(targetPath, report); got != "apache-airflow-core" {
+		t.Fatalf("target name = %q, want apache-airflow-core", got)
+	}
+}
+
+func TestDetectTargetNameFallsBackForAmbiguousRootPackages(t *testing.T) {
+	targetPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(targetPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTargetFile(t, filepath.Join(targetPath, "package.json"), `{"name":"web-client"}`)
+	writeTargetFile(t, filepath.Join(targetPath, "go.mod"), "module example.com/service\n")
+	report := &brief.Report{Git: &brief.GitInfo{Remotes: map[string]string{
+		"origin": "https://github.com/example/project.git",
+	}}}
+
+	if got := detectTargetName(targetPath, report); got != "project" {
+		t.Fatalf("target name = %q, want project", got)
+	}
+}
+
+func TestDetectTargetNameDistinguishesNestedFallbackPaths(t *testing.T) {
+	repository := t.TempDir()
+	if err := os.Mkdir(filepath.Join(repository, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	first := filepath.Join(repository, "packages", "one", "shared")
+	second := filepath.Join(repository, "packages", "two", "shared")
+	for _, targetPath := range []string{first, second} {
+		if err := os.MkdirAll(targetPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	report := &brief.Report{Git: &brief.GitInfo{Remotes: map[string]string{
+		"origin": "https://github.com/example/project.git",
+	}}}
+
+	firstName := detectTargetName(first, report)
+	secondName := detectTargetName(second, report)
+	if firstName == secondName {
+		t.Fatalf("nested target names collide: %q", firstName)
+	}
+	for _, name := range []string{firstName, secondName} {
+		if strings.ContainsAny(name, `/\\`) {
+			t.Fatalf("target name contains a path separator: %q", name)
+		}
+	}
+}
+
+func TestAnalyzeDistinguishesNestedTargetsWithSameManifestName(t *testing.T) {
+	repository := t.TempDir()
+	first := filepath.Join(repository, "apps", "one")
+	second := filepath.Join(repository, "apps", "two")
+	for _, targetPath := range []string{first, second} {
+		if err := os.MkdirAll(targetPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeTargetFile(t, filepath.Join(targetPath, "pyproject.toml"), "[project]\nname = \"shared-app\"\nversion = \"0.1.0\"\n")
+	}
+	runGit(t, repository, "init", "-q")
+	runGit(t, repository, "add", ".")
+	runGit(t, repository, "commit", "-q", "-m", "add apps")
+
+	firstTarget, err := Analyze(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTarget, err := Analyze(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstTarget.Name == secondTarget.Name {
+		t.Fatalf("nested manifest target names collide: %q", firstTarget.Name)
+	}
+	for _, name := range []string{firstTarget.Name, secondTarget.Name} {
+		if !strings.HasPrefix(name, "shared-app-") {
+			t.Errorf("target name = %q, want shared-app prefix", name)
+		}
+		if strings.ContainsAny(name, `/\\`) {
+			t.Errorf("target name contains a path separator: %q", name)
+		}
+	}
+}
+
+func TestNormalizeTargetNamePreservesChangedIdentity(t *testing.T) {
+	scoped := normalizeTargetName("@scope/package")
+	unscoped := normalizeTargetName("scope-package")
+	if scoped == unscoped {
+		t.Fatalf("normalized target names collide: %q", scoped)
+	}
+	if strings.ContainsAny(scoped, `/\\@`) {
+		t.Fatalf("normalized target name is not one component: %q", scoped)
+	}
+	if got := normalizeTargetName("apache-airflow-task-sdk"); got != "apache-airflow-task-sdk" {
+		t.Fatalf("safe target name changed to %q", got)
+	}
+}
+
+func writeTargetFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Derive target identities from root package manifests, with repository-relative fallbacks and an explicit override. Use the resolved identity consistently in workspaces, generated paths, and metadata so subdirectory targets do not collide.