### PR TITLE
Isolate Python dependency verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ whole-ecosystem scale by building and running every dependent; a small
 per-consumer suite aims to retain the relevant compatibility signal without
 building the dependent in full.
 
-**Pinned-dependency diagnosis** ([docs/logjam.md](docs/logjam.md)). For npm,
-when a dependency is held back by an upper-bound pin and the reason has been
-lost, `hyrum check --dep X@<blocked-version>` runs the generated suite against
-the blocked version and prints which assertions fail. Version selection for
-PyPI and Go is still incomplete, as described below.
+**Pinned-dependency diagnosis** ([docs/logjam.md](docs/logjam.md)). For npm and
+PyPI, when a dependency is held back by an upper-bound pin and the reason has
+been lost, `hyrum check --dep X@<blocked-version>` runs the generated suite
+against the blocked version and prints which assertions fail. Go version
+selection is still incomplete, as described below.
 
 **CVE reachability and vendoring**
 ([docs/reachability.md](docs/reachability.md)). `hyrum surface --json` gives
@@ -113,9 +113,10 @@ go install github.com/alpha-omega-security/hyrum/cmd/hyrum@latest
 ```
 
 Requires [Go 1.26+](https://go.dev/dl/) and `git` on PATH. `hyrum surface`
-needs nothing else. `hyrum check` and `gen --verify` also use the target's
-package manager and test runtime. The implemented runners require Node for
-npm, Python with pytest for PyPI, or Go for Go modules.
+needs nothing else. `hyrum check` and `gen --verify` create a scratch package
+environment and use the host test runtime. The implemented runners require
+Node for npm, Python with `venv` support for PyPI, or Go for Go modules. The
+PyPI runner installs pytest inside its virtual environment.
 
 ## Backend setup
 
@@ -235,9 +236,8 @@ hyrum corpus --upstream <purl> \
 ```
 
 Static indexing and generation cover all ecosystems listed below. Test
-execution is narrower: npm works end to end, PyPI and Go have known scratch
-setup or version-selection gaps, and the other four ecosystems have no runner
-yet.
+execution is narrower: npm and PyPI work end to end, Go has version-selection
+and result-count gaps, and the other four ecosystems have no runner yet.
 
 Static sites are classified as `production`, `test`, `example`, or
 `documentation` from their relative paths. `surface` includes every scope and
@@ -293,7 +293,7 @@ instances or callbacks.
 | purl type | languages | static extraction | test execution |
 |---|---|---|---|
 | npm | JavaScript, TypeScript | `require()`, ESM `import`, chained `.member` | `node --test` |
-| pypi | Python | `import`, `from ... import`, attribute access | pytest; scratch setup and version pinning incomplete |
+| pypi | Python | `import`, `from ... import`, attribute access | isolated virtualenv, pip, pytest |
 | golang | Go | `import "path"`, selectors, qualified types | `go test`; version pinning and result counts incomplete |
 | gem | Ruby | `require`, `Const::` and `Const.method` refs | not implemented |
 | cargo | Rust | `use crate::`, `crate::path` refs | not implemented |
@@ -316,8 +316,8 @@ Generated tests are model output. The generation skill instructs the backend
 to import only the dependency and standard library and to avoid network and
 external filesystem access, but the CLI does not enforce those rules. Review
 tests before running them. `gen --verify` and `check` run tests and package
-install hooks as your user. `check --dep X@<version>` may also change the
-target's manifest or lockfile.
+install hooks as your user. Both commands install into scratch package
+environments and leave the target's manifest and lockfile unchanged.
 
 ## License
 

--- a/cmd/hyrum/check.go
+++ b/cmd/hyrum/check.go
@@ -5,18 +5,18 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/git-pkgs/managers"
 	"github.com/git-pkgs/managers/definitions"
+	"github.com/git-pkgs/vers"
 )
 
-// cmdCheck installs one or more dependencies at given versions and runs the
-// Hyrum's tests under tests/hyrum/<dep>/ against each. Exit is non-zero when
-// any version fails tests that another version passed.
+// cmdCheck installs one or more dependencies at given versions in isolated
+// scratch environments and runs the Hyrum's tests under tests/hyrum/<dep>/
+// against each. Exit is non-zero when any suite fails.
 func cmdCheck(ctx context.Context, args []string) error {
 	fs := newFlags("check")
 	var deps stringList
@@ -37,15 +37,10 @@ func cmdCheck(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	mgr, err := detectManager(t.Path, managerHint(t))
-	if err != nil {
-		return fmt.Errorf("detect package manager: %w", err)
-	}
-
 	testsRoot := outRoot(t.Path, *root)
 	failed := false
 	for _, spec := range deps {
-		ok, err := checkOne(ctx, t, mgr, testsRoot, spec)
+		ok, err := checkOne(ctx, t, testsRoot, spec)
 		if err != nil {
 			return err
 		}
@@ -57,133 +52,133 @@ func cmdCheck(ctx context.Context, args []string) error {
 	return nil
 }
 
-// managerHint returns the package-manager name to hand to managers.Detect so
-// its ranking (which prefers bun over npm for a bare package.json) does not
-// override what a lockfile or config already indicates. brief titles some
-// names ("Bun"); managers keys are lowercase and occasionally use a
-// different identifier.
-func managerHint(t *hyrum.Target) string {
-	for _, pm := range t.Report.PackageManagers {
-		if pm.Lockfile == "" {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(t.Path, pm.Lockfile)); err == nil {
-			return managerName(pm.Name)
-		}
-	}
-	if len(t.Report.PackageManagers) > 0 {
-		return managerName(t.Report.PackageManagers[0].Name)
-	}
-	return ""
+type verificationRuntimeFactory func(string, string) (managers.Manager, hyrum.TestCommand, error)
+
+// checkOne installs one dep spec in a fresh scratch directory and runs the
+// tests generated for it. The analyzed checkout is only read.
+func checkOne(ctx context.Context, t *hyrum.Target, testsRoot, spec string) (bool, error) {
+	return checkOneWithRuntime(ctx, t, testsRoot, spec, verificationRuntime)
 }
 
-func managerName(displayName string) string {
-	name := strings.ToLower(displayName)
-	if name == "go modules" {
-		return "gomod"
-	}
-	return name
-}
-
-// checkOne installs one dep spec and runs the tests generated for it. It
-// returns whether the tests passed; a returned error is a hard failure such
-// as an unknown ecosystem, distinct from a test failure.
-func checkOne(ctx context.Context, t *hyrum.Target, mgr managers.Manager, testsRoot, spec string) (bool, error) {
+func checkOneWithRuntime(
+	ctx context.Context,
+	t *hyrum.Target,
+	testsRoot, spec string,
+	runtimeFactory verificationRuntimeFactory,
+) (bool, error) {
 	name, version := splitDepSpec(spec)
 	if err := validateRelativePath("dependency name", name); err != nil {
 		return false, err
 	}
-	d, _ := findDep(t, name)
-	if d.Ecosystem == "" {
-		d.Ecosystem = mgr.Ecosystem()
+	d, ok := findDep(t, name)
+	if !ok || d.Ecosystem == "" {
+		return false, fmt.Errorf("%s: cannot determine dependency ecosystem", name)
+	}
+	if version == "" {
+		version = constraintVersion(d.Version, d.Ecosystem)
+		if version == "" {
+			return false, fmt.Errorf("%s: no installable version found; pass --dep %s@<version>", name, name)
+		}
 	}
 
 	testDir := filepath.Join(testsRoot, name)
-	info, err := os.Stat(testDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return false, fmt.Errorf("%s: no tests at %s", name, testDir)
-		}
-		return false, fmt.Errorf("%s: inspect tests at %s: %w", name, testDir, err)
-	}
-	if !info.IsDir() {
-		return false, fmt.Errorf("%s: test suite path is not a directory: %s", name, testDir)
-	}
-	if version != "" {
-		fmt.Fprintf(os.Stderr, "→ %s add %s@%s\n", mgr.Name(), name, version)
-		if r, err := mgr.Add(ctx, name, managers.AddOptions{Version: version}); err != nil || r == nil || !r.Success() {
-			stderr := ""
-			if r != nil {
-				stderr = r.Stderr
-			}
-			fmt.Fprintf(os.Stderr, "  install failed: %v %s\n", err, stderr)
-			return false, nil
-		}
-	}
-
-	ok, out, err := runTests(ctx, t.Path, testDir, d.Ecosystem)
+	files, err := readGeneratedFiles(testDir)
 	if err != nil {
 		return false, fmt.Errorf("%s: %w", name, err)
 	}
+
+	scratch, err := os.MkdirTemp("", "hyrum-check-")
+	if err != nil {
+		return false, fmt.Errorf("%s: create scratch directory: %w", name, err)
+	}
+	defer func() { _ = os.RemoveAll(scratch) }()
+
+	mgr, testCommand, err := runtimeFactory(scratch, d.Ecosystem)
+	if err != nil {
+		return false, fmt.Errorf("%s: verification runtime: %w", name, err)
+	}
+
+	fmt.Fprintf(os.Stderr, "→ %s add %s@%s in scratch\n", mgr.Name(), name, version)
+	results := hyrum.VerifyMatrix(ctx, mgr, testCommand, scratch, name, files, []string{version})
+	if len(results) != 1 {
+		return false, fmt.Errorf("%s@%s: verification returned %d results", name, version, len(results))
+	}
+	result := results[0]
+	passed := result.Error == "" && result.Fail == 0 && result.Pass > 0
 	status := "PASS"
-	if !ok {
+	if !passed {
 		status = "FAIL"
 	}
-	fmt.Printf("%s@%s: %s\n", name, versionOr(version, d.Version), status)
-	if !ok {
-		fmt.Println(indent(out, "  "))
+	fmt.Printf("%s@%s: %s\n", name, version, status)
+	if result.Error != "" {
+		fmt.Println(indent(result.Error, "  "))
+	} else if result.Output != "" {
+		fmt.Println(indent(result.Output, "  "))
 	}
-	return ok, nil
+	return passed, nil
 }
 
-// testRunners maps a purl ecosystem type to the command that runs tests under
-// a given directory. The command runs with cwd set to the target root so
-// relative imports and node_modules resolution behave as they would in CI.
-// The dir argument is a relative path; files is the pre-globbed list of test
-// files under it for runners that need explicit paths.
-var testRunners = map[string]func(dir string, files []string) []string{
-	hyrum.EcoNPM:  func(_ string, files []string) []string { return append([]string{"node", "--test"}, files...) },
-	hyrum.EcoPyPI: func(dir string, _ []string) []string { return []string{"python3", "-m", "pytest", "-q", dir} },
-	hyrum.EcoGo:   func(dir string, _ []string) []string { return []string{"go", "test", "-v", "./" + dir + "/..."} },
-}
-
-func runTests(ctx context.Context, targetRoot, testDir, ecosystem string) (ok bool, output string, err error) {
-	rel, _ := filepath.Rel(targetRoot, testDir)
-	build, known := testRunners[ecosystem]
-	if !known {
-		return false, "", fmt.Errorf("no test runner for ecosystem %q", ecosystem)
-	}
-	relFiles, err := runnableTestFiles(targetRoot, testDir)
+func readGeneratedFiles(testDir string) ([]hyrum.GeneratedFile, error) {
+	info, err := os.Stat(testDir)
 	if err != nil {
-		return false, "", err
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("no tests at %s", testDir)
+		}
+		return nil, fmt.Errorf("inspect tests at %s: %w", testDir, err)
 	}
-	if ecosystem == hyrum.EcoNPM && len(relFiles) == 0 {
-		return false, "", fmt.Errorf("no runnable test files under %s", testDir)
+	if !info.IsDir() {
+		return nil, fmt.Errorf("test suite path is not a directory: %s", testDir)
 	}
-	argv := build(rel, relFiles)
-	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
-	cmd.Dir = targetRoot
-	out, runErr := cmd.CombinedOutput()
-	return runErr == nil, string(out), nil
-}
 
-func runnableTestFiles(targetRoot, testDir string) ([]string, error) {
-	var files []string
-	err := filepath.WalkDir(testDir, func(path string, entry fs.DirEntry, walkErr error) error {
+	var files []hyrum.GeneratedFile
+	err = filepath.WalkDir(testDir, func(path string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
 		if !entry.Type().IsRegular() || filepath.Ext(path) == ".json" {
 			return nil
 		}
-		rel, err := filepath.Rel(targetRoot, path)
+		rel, err := filepath.Rel(testDir, path)
 		if err != nil {
 			return err
 		}
-		files = append(files, rel)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files = append(files, hyrum.GeneratedFile{Path: rel, Content: string(content)})
 		return nil
 	})
-	return files, err
+	if err != nil {
+		return nil, fmt.Errorf("read tests at %s: %w", testDir, err)
+	}
+	if len(files) == 0 {
+		return nil, fmt.Errorf("no runnable test files under %s", testDir)
+	}
+	return files, nil
+}
+
+// testRunners maps a purl ecosystem type to the command that runs tests in a
+// scratch directory. files contains relative paths for runners that require
+// explicit test files.
+var testRunners = map[string]func(dir string, files []string) []string{
+	hyrum.EcoNPM: func(_ string, files []string) []string { return append([]string{"node", "--test"}, files...) },
+	hyrum.EcoGo:  func(dir string, _ []string) []string { return []string{"go", "test", "-v", "./" + dir + "/..."} },
+}
+
+func verificationRuntime(scratch, ecosystem string) (managers.Manager, hyrum.TestCommand, error) {
+	if ecosystem == hyrum.EcoPyPI {
+		return hyrum.NewPythonVenvManager(scratch), hyrum.PythonVenvTestCommand(scratch), nil
+	}
+	testCommand, ok := testRunners[ecosystem]
+	if !ok {
+		return nil, nil, fmt.Errorf("no test runner for ecosystem %q", ecosystem)
+	}
+	mgr, err := detectManagerFor(scratch, ecosystem)
+	if err != nil {
+		return nil, nil, err
+	}
+	return mgr, hyrum.TestCommand(testCommand), nil
 }
 
 func detectManager(dir, hint string) (managers.Manager, error) {
@@ -204,12 +199,28 @@ func detectManager(dir, hint string) (managers.Manager, error) {
 // then target without further setup.
 var ecosystemManager = map[string]string{
 	hyrum.EcoNPM:      "npm",
-	hyrum.EcoPyPI:     "pip",
 	hyrum.EcoGo:       "gomod",
 	hyrum.EcoGem:      "bundler",
 	hyrum.EcoCargo:    "cargo",
 	hyrum.EcoComposer: "composer",
 	hyrum.EcoHex:      "mix",
+}
+
+// constraintVersion returns the inclusive lower bound of a native version
+// constraint. Scratch verification needs a concrete version to install.
+func constraintVersion(v, ecosystem string) string {
+	if v == "" {
+		return ""
+	}
+	rangeValue, err := vers.ParseNative(v, ecosystem)
+	if err != nil {
+		return ""
+	}
+	minimum, ok := rangeValue.MinimumVersion()
+	if !ok {
+		return ""
+	}
+	return minimum
 }
 
 // detectManagerFor constructs a manager for ecosystem in dir. dir may be
@@ -229,16 +240,6 @@ func splitDepSpec(s string) (name, version string) {
 		return s, ""
 	}
 	return s[:at], s[at+1:]
-}
-
-func versionOr(v, fallback string) string {
-	if v != "" {
-		return v
-	}
-	if fallback != "" {
-		return fallback
-	}
-	return "installed"
 }
 
 func indent(s, prefix string) string {

--- a/cmd/hyrum/check_test.go
+++ b/cmd/hyrum/check_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
-	"github.com/git-pkgs/brief"
 	"github.com/git-pkgs/managers"
 )
 
@@ -42,7 +41,7 @@ func TestSplitDepSpec(t *testing.T) {
 }
 
 func TestCheckOneRejectsUnsafeDependencyPath(t *testing.T) {
-	if _, err := checkOne(context.Background(), nil, nil, t.TempDir(), "../../escape"); err == nil {
+	if _, err := checkOne(context.Background(), nil, t.TempDir(), "../../escape"); err == nil {
 		t.Fatal("checkOne accepted a dependency name that escapes the tests root")
 	}
 }
@@ -50,7 +49,7 @@ func TestCheckOneRejectsUnsafeDependencyPath(t *testing.T) {
 func TestCheckOneRejectsMissingSuite(t *testing.T) {
 	testsRoot := t.TempDir()
 	target := &hyrum.Target{Deps: []hyrum.Dep{{Name: "example", Ecosystem: hyrum.EcoNPM}}}
-	_, err := checkOne(t.Context(), target, nil, testsRoot, "example")
+	_, err := checkOne(t.Context(), target, testsRoot, "example@1.0.0")
 	if err == nil {
 		t.Fatal("checkOne accepted a missing test suite")
 	}
@@ -59,37 +58,32 @@ func TestCheckOneRejectsMissingSuite(t *testing.T) {
 	}
 }
 
-func TestRunnableTestFilesRecurses(t *testing.T) {
-	targetRoot := t.TempDir()
-	testDir := filepath.Join(targetRoot, "tests", "hyrum", "example")
+func TestReadGeneratedFilesRecursesAndExcludesMetadata(t *testing.T) {
+	testDir := filepath.Join(t.TempDir(), "tests", "hyrum", "example")
 	nested := filepath.Join(testDir, "from_repo", "websocket")
 	if err := os.MkdirAll(nested, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	testFile := filepath.Join(nested, "message.test.js")
-	if err := os.WriteFile(testFile, nil, 0o644); err != nil {
+	if err := os.WriteFile(testFile, []byte("test content"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(testDir, "meta.json"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
-	files, err := runnableTestFiles(targetRoot, testDir)
+	files, err := readGeneratedFiles(testDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, err := filepath.Rel(targetRoot, testFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(files) != 1 || files[0] != want {
-		t.Fatalf("runnableTestFiles = %q, want [%q]", files, want)
+	want := filepath.Join("from_repo", "websocket", "message.test.js")
+	if len(files) != 1 || files[0].Path != want || files[0].Content != "test content" {
+		t.Fatalf("readGeneratedFiles = %#v, want path %q with test content", files, want)
 	}
 }
 
-func TestRunTestsRejectsEmptyNodeSuite(t *testing.T) {
-	targetRoot := t.TempDir()
-	testDir := filepath.Join(targetRoot, "tests", "hyrum", "example")
+func TestReadGeneratedFilesRejectsEmptySuite(t *testing.T) {
+	testDir := filepath.Join(t.TempDir(), "tests", "hyrum", "example")
 	if err := os.MkdirAll(testDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -97,35 +91,49 @@ func TestRunTestsRejectsEmptyNodeSuite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err := runTests(t.Context(), targetRoot, testDir, hyrum.EcoNPM)
+	_, err := readGeneratedFiles(testDir)
 	if err == nil || !strings.Contains(err.Error(), "no runnable test files") {
-		t.Fatalf("runTests error = %v", err)
+		t.Fatalf("readGeneratedFiles error = %v", err)
 	}
 }
 
-func TestManagerHintMapsGoModulesToGomod(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "go.sum"), nil, 0o644); err != nil {
+func TestCmdCheckDoesNotRequireTargetPackageManager(t *testing.T) {
+	target := t.TempDir()
+	pyproject := `[project]
+name = "consumer"
+version = "0.1.0"
+dependencies = ["idna==3.7"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+`
+	if err := os.WriteFile(filepath.Join(target, "pyproject.toml"), []byte(pyproject), 0o644); err != nil {
 		t.Fatal(err)
-	}
-	target := &hyrum.Target{
-		Path: dir,
-		Report: &brief.Report{PackageManagers: []brief.Detection{{
-			Name:     "Go Modules",
-			Lockfile: "go.sum",
-		}}},
 	}
 
-	hint := managerHint(target)
-	if hint != "gomod" {
-		t.Fatalf("managerHint = %q, want gomod", hint)
+	err := cmdCheck(t.Context(), []string{
+		"--dep", "idna@3.7",
+		"--tests", filepath.Join(target, "missing-tests"),
+		target,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no tests at") {
+		t.Fatalf("cmdCheck error = %v, want missing-suite error after target analysis", err)
 	}
-	mgr, err := detectManager(dir, hint)
-	if err != nil {
-		t.Fatal(err)
+}
+
+func TestConstraintVersion(t *testing.T) {
+	cases := []struct{ in, ecosystem, want string }{
+		{"^1.2.3", hyrum.EcoNPM, "1.2.3"},
+		{"~> 4.0", hyrum.EcoGem, "4.0"},
+		{"~=2.3", hyrum.EcoPyPI, "2.3"},
+		{">=2.3,!=2.3", hyrum.EcoPyPI, ""},
+		{"*", hyrum.EcoNPM, ""},
 	}
-	if mgr.Name() != "gomod" {
-		t.Fatalf("detected manager = %q, want gomod", mgr.Name())
+	for _, test := range cases {
+		if got := constraintVersion(test.in, test.ecosystem); got != test.want {
+			t.Errorf("constraintVersion(%q, %q) = %q, want %q", test.in, test.ecosystem, got, test.want)
+		}
 	}
 }
 
@@ -139,28 +147,76 @@ func TestDetectManagerForGoUsesGomod(t *testing.T) {
 	}
 }
 
+func TestVerificationRuntimePyPIUsesScratchVirtualenv(t *testing.T) {
+	scratch := t.TempDir()
+	mgr, testCommand, err := verificationRuntime(scratch, hyrum.EcoPyPI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mgr.Name() != "pip" || mgr.Ecosystem() != hyrum.EcoPyPI {
+		t.Fatalf("manager = %s/%s, want pip/%s", mgr.Name(), mgr.Ecosystem(), hyrum.EcoPyPI)
+	}
+	argv := testCommand(".", nil)
+	if len(argv) == 0 || !strings.HasPrefix(argv[0], filepath.Join(scratch, ".venv")) {
+		t.Fatalf("test command = %q, want interpreter under scratch virtualenv", argv)
+	}
+}
+
 type addErrorManager struct {
 	managers.Manager
+	onAdd func(string, managers.AddOptions)
 }
 
 func (addErrorManager) Name() string      { return "test" }
 func (addErrorManager) Ecosystem() string { return hyrum.EcoNPM }
-func (addErrorManager) Add(context.Context, string, managers.AddOptions) (*managers.Result, error) {
+func (addErrorManager) Init(context.Context) (*managers.Result, error) {
+	return &managers.Result{}, nil
+}
+func (m addErrorManager) Add(_ context.Context, name string, opts managers.AddOptions) (*managers.Result, error) {
+	if m.onAdd != nil {
+		m.onAdd(name, opts)
+	}
 	return nil, errors.New("invalid package")
 }
 
-func TestCheckOneHandlesAddErrorWithoutResult(t *testing.T) {
+func TestCheckOneUsesAndRemovesScratchDirectory(t *testing.T) {
 	testsRoot := t.TempDir()
-	if err := os.Mkdir(filepath.Join(testsRoot, "example"), 0o755); err != nil {
+	testDir := filepath.Join(testsRoot, "example")
+	if err := os.Mkdir(testDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	target := &hyrum.Target{Path: t.TempDir()}
+	if err := os.WriteFile(filepath.Join(testDir, "example.test.js"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := &hyrum.Target{
+		Path: t.TempDir(),
+		Deps: []hyrum.Dep{{Name: "example", Version: "1.0.0", Ecosystem: hyrum.EcoNPM}},
+	}
+	var scratch string
+	factory := func(dir, ecosystem string) (managers.Manager, hyrum.TestCommand, error) {
+		scratch = dir
+		if ecosystem != hyrum.EcoNPM {
+			t.Fatalf("ecosystem = %q, want %q", ecosystem, hyrum.EcoNPM)
+		}
+		mgr := addErrorManager{onAdd: func(name string, opts managers.AddOptions) {
+			if name != "example" || opts.Version != "1.0.0" || !opts.Exact {
+				t.Errorf("add = %s %+v, want example at exact version 1.0.0", name, opts)
+			}
+		}}
+		return mgr, func(string, []string) []string { return nil }, nil
+	}
 
-	ok, err := checkOne(t.Context(), target, addErrorManager{}, testsRoot, "example@1.0.0")
+	ok, err := checkOneWithRuntime(t.Context(), target, testsRoot, "example", factory)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok {
 		t.Fatal("checkOne reported a failed install as successful")
+	}
+	if scratch == "" || scratch == target.Path {
+		t.Fatalf("scratch = %q, target = %q", scratch, target.Path)
+	}
+	if _, err := os.Stat(scratch); !os.IsNotExist(err) {
+		t.Fatalf("scratch directory still exists: %v", err)
 	}
 }

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -740,22 +740,18 @@ func (p *pipeline) runVerify(ctx context.Context, ws string, d hyrum.Dep, baseli
 	if baseline == "" {
 		return []hyrum.VerifyResult{{Error: "baseline version is unresolved"}}
 	}
-	tc, ok := testRunners[d.Ecosystem]
-	if !ok {
-		return []hyrum.VerifyResult{{Error: "no test runner for ecosystem " + d.Ecosystem}}
-	}
 	scratch := filepath.Join(ws, "verify")
 	_ = os.RemoveAll(scratch)
 	if err := os.MkdirAll(scratch, 0o755); err != nil {
 		return []hyrum.VerifyResult{{Error: err.Error()}}
 	}
-	mgr, err := detectManagerFor(scratch, d.Ecosystem)
+	mgr, testCommand, err := verificationRuntime(scratch, d.Ecosystem)
 	if err != nil {
-		return []hyrum.VerifyResult{{Error: fmt.Sprintf("manager for %s: %v", d.Ecosystem, err)}}
+		return []hyrum.VerifyResult{{Error: fmt.Sprintf("verification runtime for %s: %v", d.Ecosystem, err)}}
 	}
 	versions := []string{baseline, latest}
 	fmt.Fprintf(os.Stderr, "  [verify] %s at %v\n", d.Name, versions)
-	results := hyrum.VerifyMatrix(ctx, mgr, hyrum.TestCommand(tc), scratch, d.Name, files, versions)
+	results := hyrum.VerifyMatrix(ctx, mgr, testCommand, scratch, d.Name, files, versions)
 	for _, r := range results {
 		if r.Error != "" {
 			fmt.Fprintf(os.Stderr, "    %s: error: %s\n", r.Version, r.Error)

--- a/cmd/hyrum/helpers_test.go
+++ b/cmd/hyrum/helpers_test.go
@@ -146,18 +146,6 @@ func TestSplitDependentSpec(t *testing.T) {
 	}
 }
 
-func TestVersionOr(t *testing.T) {
-	if versionOr("1.0", "2.0") != "1.0" {
-		t.Error("prefer explicit")
-	}
-	if versionOr("", "2.0") != "2.0" {
-		t.Error("fallback")
-	}
-	if versionOr("", "") != "installed" {
-		t.Error("default")
-	}
-}
-
 func TestIndent(t *testing.T) {
 	if got := indent("a\nb\n", "  "); got != "  a\n  b" {
 		t.Errorf("got %q", got)

--- a/docs/consumer-ci.md
+++ b/docs/consumer-ci.md
@@ -49,12 +49,13 @@ jobs:
       - run: hyrum check --dep ws@${{ steps.bump.outputs.version }}
 ```
 
-`check` installs the candidate version via the project's own package manager
-and runs `tests/hyrum/ws/`, exiting non-zero with the assertion diff when a
-pinned behaviour has changed:
+`check` installs the candidate version in a scratch package environment and
+runs `tests/hyrum/ws/`, exiting non-zero with the assertion diff when a pinned
+behaviour has changed. The project's manifest, lockfile, and installed
+dependencies remain unchanged:
 
 ```
-→ npm add ws@8.21.3
+→ npm add ws@8.21.3 in scratch
 ws@8.21.3: FAIL
   ✖ delivers text message payloads as strings (1.2ms)
     AssertionError: Expected values to be strictly equal:

--- a/internal/hyrum/python.go
+++ b/internal/hyrum/python.go
@@ -70,6 +70,9 @@ func (m *pythonVenvManager) Add(
 }
 
 func pythonVenvExecutable(root string) string {
+	if absolute, err := filepath.Abs(root); err == nil {
+		root = absolute
+	}
 	if runtime.GOOS == "windows" {
 		return filepath.Join(root, pythonVenvDir, "Scripts", "python.exe")
 	}

--- a/internal/hyrum/python.go
+++ b/internal/hyrum/python.go
@@ -1,0 +1,77 @@
+package hyrum
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+
+	"github.com/git-pkgs/managers"
+)
+
+const pythonVenvDir = ".venv"
+
+// NewPythonVenvManager returns the manager used for isolated PyPI test runs.
+// VerifyMatrix only calls Init, Add, Name, and Ecosystem on the returned value.
+func NewPythonVenvManager(dir string) managers.Manager {
+	return &pythonVenvManager{
+		Manager:   nil,
+		dir:       dir,
+		bootstrap: "python3",
+		python:    pythonVenvExecutable(dir),
+		runner:    managers.NewExecRunner(),
+	}
+}
+
+// PythonVenvTestCommand runs pytest with the interpreter created by
+// NewPythonVenvManager in scratch.
+func PythonVenvTestCommand(scratch string) TestCommand {
+	python := pythonVenvExecutable(scratch)
+	return func(dir string, _ []string) []string {
+		return []string{python, "-m", "pytest", "-q", dir}
+	}
+}
+
+type pythonVenvManager struct {
+	managers.Manager
+	dir       string
+	bootstrap string
+	python    string
+	runner    managers.Runner
+}
+
+func (m *pythonVenvManager) Name() string { return "pip" }
+
+func (m *pythonVenvManager) Ecosystem() string { return EcoPyPI }
+
+func (m *pythonVenvManager) Init(ctx context.Context) (*managers.Result, error) {
+	result, err := m.runner.Run(ctx, m.dir, m.bootstrap, "-m", "venv", pythonVenvDir)
+	if err != nil || result == nil || !result.Success() {
+		return result, err
+	}
+	return m.runner.Run(ctx, m.dir,
+		m.python, "-m", "pip", "install",
+		"--disable-pip-version-check", "--no-input", "--quiet", "--", "pytest",
+	)
+}
+
+func (m *pythonVenvManager) Add(
+	ctx context.Context,
+	pkg string,
+	opts managers.AddOptions,
+) (*managers.Result, error) {
+	requirement := pkg
+	if opts.Version != "" {
+		requirement += "==" + opts.Version
+	}
+	return m.runner.Run(ctx, m.dir,
+		m.python, "-m", "pip", "install",
+		"--disable-pip-version-check", "--no-input", "--quiet", "--force-reinstall", "--", requirement,
+	)
+}
+
+func pythonVenvExecutable(root string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(root, pythonVenvDir, "Scripts", "python.exe")
+	}
+	return filepath.Join(root, pythonVenvDir, "bin", "python")
+}

--- a/internal/hyrum/python_test.go
+++ b/internal/hyrum/python_test.go
@@ -47,3 +47,10 @@ func TestPythonVenvTestCommandUsesScratchInterpreter(t *testing.T) {
 		t.Fatalf("interpreter path = %q, want absolute", got[0])
 	}
 }
+
+func TestPythonVenvTestCommandResolvesRelativeScratch(t *testing.T) {
+	got := PythonVenvTestCommand(filepath.Join("relative", "scratch"))("tests", nil)
+	if !filepath.IsAbs(got[0]) {
+		t.Fatalf("interpreter path = %q, want absolute path for relative scratch", got[0])
+	}
+}

--- a/internal/hyrum/python_test.go
+++ b/internal/hyrum/python_test.go
@@ -1,0 +1,49 @@
+package hyrum
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/git-pkgs/managers"
+)
+
+func TestPythonVenvManagerInitializesAndAddsExactVersion(t *testing.T) {
+	runner := managers.NewMockRunner()
+	dir := t.TempDir()
+	python := pythonVenvExecutable(dir)
+	mgr := &pythonVenvManager{
+		dir:       dir,
+		bootstrap: "python3",
+		python:    python,
+		runner:    runner,
+	}
+
+	if _, err := mgr.Init(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mgr.Add(t.Context(), "example", managers.AddOptions{Version: "1.2.3", Exact: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := [][]string{
+		{"python3", "-m", "venv", pythonVenvDir},
+		{python, "-m", "pip", "install", "--disable-pip-version-check", "--no-input", "--quiet", "--", "pytest"},
+		{python, "-m", "pip", "install", "--disable-pip-version-check", "--no-input", "--quiet", "--force-reinstall", "--", "example==1.2.3"},
+	}
+	if !reflect.DeepEqual(runner.Captured, want) {
+		t.Fatalf("commands = %#v, want %#v", runner.Captured, want)
+	}
+}
+
+func TestPythonVenvTestCommandUsesScratchInterpreter(t *testing.T) {
+	scratch := t.TempDir()
+	got := PythonVenvTestCommand(scratch)("tests", nil)
+	want := []string{pythonVenvExecutable(scratch), "-m", "pytest", "-q", "tests"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("command = %q, want %q", got, want)
+	}
+	if !filepath.IsAbs(got[0]) {
+		t.Fatalf("interpreter path = %q, want absolute", got[0])
+	}
+}

--- a/internal/hyrum/verify_integration_test.go
+++ b/internal/hyrum/verify_integration_test.go
@@ -79,7 +79,16 @@ func TestVerifyMatrixPyPI(t *testing.T) {
 		t.Skip("python3 not on PATH")
 	}
 
-	scratch := t.TempDir()
+	working := t.TempDir()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(working); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(previous) })
+	scratch := "verify"
 	files := []GeneratedFile{{
 		Path: "test_idna.py",
 		Content: `import idna

--- a/internal/hyrum/verify_integration_test.go
+++ b/internal/hyrum/verify_integration_test.go
@@ -64,3 +64,47 @@ func TestVerifyMatrixNPM(t *testing.T) {
 		t.Error("latest with failures should retain runner output for validate")
 	}
 }
+
+// TestVerifyMatrixPyPI exercises virtualenv creation, dependency replacement,
+// and pytest with two published versions. It is opt-in because it downloads
+// packages from PyPI.
+func TestVerifyMatrixPyPI(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration")
+	}
+	if os.Getenv("HYRUM_TEST_PYPI") == "" {
+		t.Skip("set HYRUM_TEST_PYPI=1 to run the PyPI integration test")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH")
+	}
+
+	scratch := t.TempDir()
+	files := []GeneratedFile{{
+		Path: "test_idna.py",
+		Content: `import idna
+
+def test_idna_encode():
+    assert idna.encode("example.com") == b"example.com"
+`,
+	}}
+	versions := []string{"3.6", "3.7"}
+	results := VerifyMatrix(
+		t.Context(),
+		NewPythonVenvManager(scratch),
+		PythonVenvTestCommand(scratch),
+		scratch,
+		"idna",
+		files,
+		versions,
+	)
+
+	if len(results) != len(versions) {
+		t.Fatalf("results = %d, want %d: %+v", len(results), len(versions), results)
+	}
+	for i, result := range results {
+		if result.Version != versions[i] || result.Error != "" || result.Fail != 0 || result.Pass == 0 {
+			t.Errorf("version %s: %+v", versions[i], result)
+		}
+	}
+}


### PR DESCRIPTION
Run dependency verification in scratch package environments so `check` leaves the target checkout unchanged. For PyPI, create a virtualenv for each run, install pytest and the exact dependency version there, and invoke pytest through that interpreter. Reuse the same runtime for `gen --verify` and update the user guidance.