### PR TITLE
ci: disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "enabledManagers": ["gomod", "github-actions", "custom.regex"],
-  "dependencyDashboard": true,
   "automerge": false,
   "internalChecksFilter": "strict",
   "customManagers": [
@@ -42,19 +41,12 @@
       "description": "Raising the go directive raises the minimum Go version for every consumer",
       "matchManagers": ["gomod"],
       "matchDepTypes": ["golang", "toolchain"],
-      "groupName": "Go language version",
-      "dependencyDashboardApproval": true
+      "groupName": "Go language version"
     },
     {
       "matchManagers": ["gomod"],
       "matchDepTypes": ["indirect"],
       "enabled": true
-    },
-    {
-      "description": "Require explicit approval before starting a Go module major-version migration",
-      "matchManagers": ["gomod"],
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
     },
     {
       "description": "An indirect dependency's major version is decided by whatever requires it, never here",


### PR DESCRIPTION
The `config:recommended` preset enables the Dependency Dashboard, and two Hyrum rules depend on it: Go language and toolchain updates are held for approval because they raise the minimum Go version for consumers, while direct Go major updates are also held for approval. That makes #22 a required part of the update workflow instead of presenting those changes directly for pull-request review.

This adds `:disableDependencyDashboard` after `config:recommended` so the override wins, removes dashboard approval from the Go language group, and removes the direct-major approval rule. Go language and toolchain updates stay grouped separately, indirect Go majors remain disabled, and runner-image updates remain disabled because Renovate cannot see the test matrix.

The configuration validates successfully against Renovate 44.46.5.

Codex was used to implement this.