### PR TITLE
fix: root untrusted file I/O and sanitize rendered output

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,14 @@ the target repository. For safety, `out` in an automatically discovered
 target configuration must remain inside that target; an explicitly supplied
 `--config` may select an external output path.
 
-An automatically discovered config cannot select `work`: that value is ignored
-unless the operator supplies the config with `--config`. `--work` is always
-honored. A relative `work` value from an explicit config is rooted at the
-directory containing that file; absolute paths and `~/...` are accepted.
+An automatically discovered config cannot select `backend`, `models`, or
+`work`: those values are ignored unless the operator supplies the config with
+`--config`. This prevents an untrusted checkout from choosing which provider
+credential or paid model Hyrum invokes. Explicit flags are always honored. A
+relative `work` value from an explicit config is rooted at the directory
+containing that file; absolute paths and `~/...` are accepted. Without either,
+reusable state lives under the current user's cache directory in a private
+`hyrum/work` root rather than a shared temporary directory.
 
 Dependency overrides may be keyed by manifest name or full purl; a purl entry
 wins for fields also set by a name entry. `skip: true` removes a dependency
@@ -204,9 +208,11 @@ to individual skills without backend-specific configuration. See
 By default the backend runs on the host, so its CLI (`claude`, `codex`, ...)
 must be on PATH and file-based logins under `~/.claude` or `~/.codex` work.
 `--container default` runs it inside
-`ghcr.io/alpha-omega-security/scrutineer-runner` instead: the image bundles
+the digest-pinned `ghcr.io/alpha-omega-security/scrutineer-runner` image
+instead: the image bundles
 all four backend CLIs plus Node, Python, and Go toolchains. The container has a
-fresh HOME, the target repository mounted read-only, and dropped capabilities,
+fresh HOME, the target repository and reusable dependency checkout mounted
+read-only, and dropped capabilities,
 which is the recommended mode for `corpus --discover` or any target you did
 not author; see [SECURITY.md](SECURITY.md) and
 [threatmodel.md](threatmodel.md). Because HOME is fresh, authentication in
@@ -273,10 +279,13 @@ observed calls and cite the source line or commit each was derived from. With
 `--verify`, supported tests are run in a scratch directory against the
 concrete registry release
 selected for the target's baseline constraint and the dependency's latest
-release. A fourth `hyrum-validate` step then classifies
-latest-version failures as real behaviour changes, over-specific assertions,
-or environment problems, and flags tests whose only assertion is a shape
-check. Per-version results and per-test verdicts land in `meta.json`. See
+release. Verification reports what the ecosystem test runner observed; a
+`PASS` means that no failure was observed, not that the test process supplied
+an authenticated verdict. A non-zero runner exit is always an error even when
+its output contains a passing summary. A fourth `hyrum-validate` step then
+classifies latest-version failures as real behaviour changes, over-specific
+assertions, or environment problems, and flags tests whose only assertion is a
+shape check. Per-version results and per-test verdicts land in `meta.json`. See
 [docs/skills.md](docs/skills.md) for what each step reads and writes.
 
 ## Ecosystems

--- a/cmd/hyrum/batch.go
+++ b/cmd/hyrum/batch.go
@@ -46,8 +46,8 @@ type tracedSurface struct {
 	Notes       string            `json:"notes,omitempty"`
 }
 
-func readUsageSurface(path string) (*usage.Surface, error) {
-	contents, err := os.ReadFile(path)
+func readUsageSurface(ws, name string) (*usage.Surface, error) {
+	contents, err := readWorkspaceFile(ws, name)
 	if err != nil {
 		return nil, err
 	}
@@ -60,11 +60,8 @@ func readUsageSurface(path string) (*usage.Surface, error) {
 
 func stageUsageBatches(ws string, batches []*usage.Surface) error {
 	for i, batch := range batches {
-		dir := filepath.Join(ws, "batches", batchDirectory(i+1))
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			return err
-		}
-		if err := writeJSON(filepath.Join(dir, "usage.json"), batch); err != nil {
+		name := filepath.Join("batches", batchDirectory(i+1), "usage.json")
+		if err := writeWorkspaceJSON(ws, name, batch); err != nil {
 			return err
 		}
 	}
@@ -127,14 +124,13 @@ func (p *pipeline) runBatchHistory(
 	runner hyrum.Runner,
 	ws, depName string,
 ) ([]byte, float64, []string, error) {
-	breaksPath := filepath.Join(ws, "breaks.json")
-	_ = os.Remove(breaksPath)
+	_ = removeWorkspacePath(ws, "breaks.json", false)
 	result, err := p.runGenerationStep(ctx, runner, ws, depName, skillSteps[1])
 	if err != nil {
 		return nil, 0, nil, nil
 	}
 	breaks := append([]byte(nil), result.Output...)
-	if err := os.WriteFile(breaksPath, breaks, 0o644); err != nil {
+	if err := writeWorkspaceFile(ws, "breaks.json", breaks); err != nil {
 		return nil, 0, nil, err
 	}
 	var recovered []string
@@ -167,7 +163,7 @@ func (p *pipeline) runGenerationBatch(
 		}
 	}
 
-	_ = os.Remove(filepath.Join(ws, "tests.json"))
+	_ = removeWorkspacePath(ws, "tests.json", false)
 	generateResult, err := p.runGenerationStep(ctx, runner, ws, depName, skillSteps[2])
 	if err != nil {
 		return nil, err
@@ -179,17 +175,16 @@ func (p *pipeline) runGenerationBatch(
 }
 
 func prepareGenerationBatch(ws string, batch *usage.Surface, breaks []byte, number int) error {
-	if err := writeJSON(filepath.Join(ws, "usage.json"), batch); err != nil {
+	if err := writeWorkspaceJSON(ws, "usage.json", batch); err != nil {
 		return err
 	}
-	breaksPath := filepath.Join(ws, "breaks.json")
 	if number == 1 && len(breaks) > 0 {
-		return os.WriteFile(breaksPath, breaks, 0o644)
+		return writeWorkspaceFile(ws, "breaks.json", breaks)
 	}
-	if err := os.Remove(breaksPath); err != nil && !os.IsNotExist(err) {
+	if err := removeWorkspacePath(ws, "breaks.json", false); err != nil {
 		return err
 	}
-	_ = os.Remove(filepath.Join(ws, "surface.json"))
+	_ = removeWorkspacePath(ws, "surface.json", false)
 	return nil
 }
 
@@ -200,7 +195,7 @@ func (b *completedGenerationBatch) recordUsageResult(ws string, result *hyrum.Ru
 		b.RecoveredSteps = append(b.RecoveredSteps, skillSteps[0].name+" batch "+strconv.Itoa(b.Metadata.Number))
 	}
 	b.Trace = append(json.RawMessage(nil), result.Output...)
-	if err := os.WriteFile(filepath.Join(ws, "surface.json"), result.Output, 0o644); err != nil {
+	if err := writeWorkspaceFile(ws, "surface.json", result.Output); err != nil {
 		return err
 	}
 	return writeBatchRaw(ws, b.Metadata.Number, "surface.json", result.Output)
@@ -237,35 +232,35 @@ func restoreBatchedWorkspace(
 	traced []json.RawMessage,
 	generated hyrum.GenerateResult,
 ) error {
-	if err := writeJSON(filepath.Join(ws, "usage.json"), mergeUsageBatches(batches)); err != nil {
+	if err := writeWorkspaceJSON(ws, "usage.json", mergeUsageBatches(batches)); err != nil {
 		return err
 	}
 	if len(breaks) > 0 {
-		if err := os.WriteFile(filepath.Join(ws, "breaks.json"), breaks, 0o644); err != nil {
+		if err := writeWorkspaceFile(ws, "breaks.json", breaks); err != nil {
 			return err
 		}
 	}
 	if err := restoreMergedTrace(ws, traced); err != nil {
 		return err
 	}
-	return writeJSON(filepath.Join(ws, "tests.json"), generated)
+	return writeWorkspaceJSON(ws, "tests.json", generated)
 }
 
 func restoreMergedTrace(ws string, traced []json.RawMessage) error {
 	surface, err := mergeTracedSurfaces(traced)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  merge surface.json: %v (validation will use usage.json)\n", err)
-		_ = os.Remove(filepath.Join(ws, "surface.json"))
+		fmt.Fprintf(os.Stderr, "  merge surface.json: %s (validation will use usage.json)\n", safeLine(err.Error()))
+		_ = removeWorkspacePath(ws, "surface.json", false)
 		return nil
 	}
 	if surface == nil {
 		return nil
 	}
-	return writeJSON(filepath.Join(ws, "surface.json"), surface)
+	return writeWorkspaceJSON(ws, "surface.json", surface)
 }
 
 func writeBatchRaw(ws string, number int, name string, contents []byte) error {
-	return os.WriteFile(filepath.Join(ws, "batches", batchDirectory(number), name), contents, 0o644)
+	return writeWorkspaceFile(ws, filepath.Join("batches", batchDirectory(number), name), contents)
 }
 
 func usageSymbolNames(surface *usage.Surface) []string {

--- a/cmd/hyrum/batch_test.go
+++ b/cmd/hyrum/batch_test.go
@@ -31,7 +31,7 @@ func (r *batchingRunner) RunSkill(
 	case "hyrum-history":
 		return &hyrum.RunResult{Output: json.RawMessage(`{"breaks":[]}`), CostUSD: 0.1}, nil
 	case "hyrum-usage":
-		surface, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+		surface, err := readUsageSurface(ws, "usage.json")
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +102,7 @@ func TestRunBatchedGenerateSkillsMergesOutputsAndMetadata(t *testing.T) {
 		t.Fatalf("costs = total %v, history %v", run.TotalCost, run.HistoryCost)
 	}
 
-	staged, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+	staged, err := readUsageSurface(ws, "usage.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/hyrum/check.go
+++ b/cmd/hyrum/check.go
@@ -98,7 +98,7 @@ func checkOneWithRuntime(
 		return false, fmt.Errorf("%s: verification runtime: %w", name, err)
 	}
 
-	fmt.Fprintf(os.Stderr, "→ %s add %s@%s in scratch\n", mgr.Name(), name, version)
+	fmt.Fprintf(os.Stderr, "→ %s add %s@%s in scratch\n", safeLine(mgr.Name()), safeLine(name), safeLine(version))
 	results := hyrum.VerifyMatrix(ctx, mgr, testCommand, scratch, name, files, []string{version})
 	if len(results) != 1 {
 		return false, fmt.Errorf("%s@%s: verification returned %d results", name, version, len(results))
@@ -109,13 +109,22 @@ func checkOneWithRuntime(
 	if !passed {
 		status = "FAIL"
 	}
-	fmt.Printf("%s@%s: %s\n", name, version, status)
-	if result.Error != "" {
-		fmt.Println(indent(result.Error, "  "))
-	} else if result.Output != "" {
-		fmt.Println(indent(result.Output, "  "))
-	}
+	fmt.Printf("%s@%s: %s\n", safeLine(name), safeLine(version), status)
+	printVerificationDetails(result)
 	return passed, nil
+}
+
+func printVerificationDetails(result hyrum.VerifyResult) {
+	if result.Output != "" {
+		if result.Error != "" {
+			fmt.Println(indent(safeLine(result.Error)))
+		}
+		fmt.Println(indent(safeText(result.Output)))
+		return
+	}
+	if result.Error != "" {
+		fmt.Println(indent(safeText(result.Error)))
+	}
 }
 
 func readGeneratedFiles(testDir string) ([]hyrum.GeneratedFile, error) {
@@ -242,10 +251,10 @@ func splitDepSpec(s string) (name, version string) {
 	return s[:at], s[at+1:]
 }
 
-func indent(s, prefix string) string {
+func indent(s string) string {
 	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
 	for i := range lines {
-		lines[i] = prefix + lines[i]
+		lines[i] = "  " + lines[i]
 	}
 	return strings.Join(lines, "\n")
 }

--- a/cmd/hyrum/check_test.go
+++ b/cmd/hyrum/check_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -167,6 +168,19 @@ type addErrorManager struct {
 	onAdd func(string, managers.AddOptions)
 }
 
+type addSuccessManager struct {
+	managers.Manager
+}
+
+func (addSuccessManager) Name() string      { return "test" }
+func (addSuccessManager) Ecosystem() string { return hyrum.EcoNPM }
+func (addSuccessManager) Init(context.Context) (*managers.Result, error) {
+	return &managers.Result{}, nil
+}
+func (addSuccessManager) Add(context.Context, string, managers.AddOptions) (*managers.Result, error) {
+	return &managers.Result{}, nil
+}
+
 func (addErrorManager) Name() string      { return "test" }
 func (addErrorManager) Ecosystem() string { return hyrum.EcoNPM }
 func (addErrorManager) Init(context.Context) (*managers.Result, error) {
@@ -177,6 +191,61 @@ func (m addErrorManager) Add(_ context.Context, name string, opts managers.AddOp
 		m.onAdd(name, opts)
 	}
 	return nil, errors.New("invalid package")
+}
+
+const assertionDiffMarker = "ASSERTION_DIFF_EXPECTED_VALUE"
+
+func TestCheckOneDisplaysFullFailureOutputAndExitHeader(t *testing.T) {
+	testsRoot := t.TempDir()
+	testDir := filepath.Join(testsRoot, "example")
+	if err := os.Mkdir(testDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(testDir, "example.test.js"), []byte("test"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	target := &hyrum.Target{
+		Path: t.TempDir(),
+		Deps: []hyrum.Dep{{Name: "example", Version: "1.0.0", Ecosystem: hyrum.EcoNPM}},
+	}
+	var factory verificationRuntimeFactory = func(string, string) (managers.Manager, hyrum.TestCommand, error) {
+		command := func(string, []string) []string {
+			return []string{os.Args[0], "-test.run=TestCheckFailureOutputHelper", "--", "long-failure"}
+		}
+		return addSuccessManager{}, command, nil
+	}
+
+	var ok bool
+	output, err := captureStdout(t, func() error {
+		var checkErr error
+		ok, checkErr = checkOneWithRuntime(t.Context(), target, testsRoot, "example", factory)
+		return checkErr
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok {
+		t.Fatal("checkOne reported a failing runner as successful")
+	}
+	if !strings.Contains(output, "exit status 1") {
+		t.Fatalf("runner exit header missing from output: %q", output)
+	}
+	if !strings.Contains(output, assertionDiffMarker) {
+		t.Fatalf("full assertion output was not displayed: %q", output)
+	}
+	if strings.Contains(output, "\x1b") {
+		t.Fatalf("terminal controls were not sanitized: %q", output)
+	}
+}
+
+func TestCheckFailureOutputHelper(*testing.T) {
+	if len(os.Args) < 2 || os.Args[len(os.Args)-1] != "long-failure" {
+		return
+	}
+	fmt.Printf("\x1b[31m%s\x1b[0m\n", assertionDiffMarker)
+	fmt.Print(strings.Repeat("stack frame outside the short error tail\n", 40))
+	fmt.Println("fail 1")
+	os.Exit(1)
 }
 
 func TestCheckOneUsesAndRemovesScratchDirectory(t *testing.T) {
@@ -193,7 +262,7 @@ func TestCheckOneUsesAndRemovesScratchDirectory(t *testing.T) {
 		Deps: []hyrum.Dep{{Name: "example", Version: "1.0.0", Ecosystem: hyrum.EcoNPM}},
 	}
 	var scratch string
-	factory := func(dir, ecosystem string) (managers.Manager, hyrum.TestCommand, error) {
+	var factory verificationRuntimeFactory = func(dir, ecosystem string) (managers.Manager, hyrum.TestCommand, error) {
 		scratch = dir
 		if ecosystem != hyrum.EcoNPM {
 			t.Fatalf("ecosystem = %q, want %q", ecosystem, hyrum.EcoNPM)
@@ -206,12 +275,20 @@ func TestCheckOneUsesAndRemovesScratchDirectory(t *testing.T) {
 		return mgr, func(string, []string) []string { return nil }, nil
 	}
 
-	ok, err := checkOneWithRuntime(t.Context(), target, testsRoot, "example", factory)
+	var ok bool
+	output, err := captureStdout(t, func() error {
+		var checkErr error
+		ok, checkErr = checkOneWithRuntime(t.Context(), target, testsRoot, "example", factory)
+		return checkErr
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ok {
 		t.Fatal("checkOne reported a failed install as successful")
+	}
+	if !strings.Contains(output, "install example@1.0.0: invalid package") {
+		t.Fatalf("install error fallback missing from output: %q", output)
 	}
 	if scratch == "" || scratch == target.Path {
 		t.Fatalf("scratch = %q, target = %q", scratch, target.Path)

--- a/cmd/hyrum/corpus.go
+++ b/cmd/hyrum/corpus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,10 +26,10 @@ func cmdCorpus(ctx context.Context, args []string) error {
 	upstream := fs.String("upstream", "", "upstream dependency name as it appears in dependents' manifests (required)")
 	upstreamRepo := fs.String("upstream-repo", "", "upstream repository URL for --discover (default: registry lookup on --upstream purl)")
 	var explicitDeps stringList
-	fs.Var(&explicitDeps, "dependent", "dependent repository URL (repeatable)")
+	fs.Var(&explicitDeps, "dependent", "dependent repository URL (repeatable; use a Git credential helper for private repositories)")
 	discoverN := fs.Int("discover", 0, "auto-discover N dependents via ecosyste.ms (git-pkgs/dependents)")
 	out := fs.String("out", "", "output directory for the aggregated corpus (required)")
-	work := fs.String("work", filepath.Join(os.TempDir(), "hyrum-corpus"), "working directory for clones and skill workspaces")
+	work := fs.String("work", defaultWorkPath("corpus"), "working directory for clones and skill workspaces")
 	backend := fs.String("backend", "claude", "harness backend: "+harness.Names())
 	run := fs.Bool("run", false, "invoke the backend (otherwise stage only)")
 	outlineBytes := fs.Int("outline-bytes", defaultOutlineBytes, "maximum bytes in each dependency outline")
@@ -44,6 +45,16 @@ func cmdCorpus(ctx context.Context, args []string) error {
 	}
 	if *outlineBytes <= 0 {
 		return fmt.Errorf("--outline-bytes must be greater than zero")
+	}
+	if *upstreamRepo != "" {
+		if err := validateRepositoryURL(*upstreamRepo); err != nil {
+			return fmt.Errorf("--upstream-repo: %w", err)
+		}
+	}
+	if !visitedFlags(fs)["work"] {
+		if err := ensurePrivateWorkRoot(*work); err != nil {
+			return err
+		}
 	}
 
 	h, err := harness.ByName(*backend)
@@ -68,19 +79,24 @@ func cmdCorpus(ctx context.Context, args []string) error {
 
 	var corpusErrs []error
 	for _, spec := range specs {
-		display := clone.RedactURL(spec)
-		url, ref := splitDependentSpec(spec)
-		fmt.Fprintf(os.Stderr, "▶ dependent %s\n", display)
-		dir := filepath.Join(*work, "targets", slugify(url))
-		if err := clone.Ensure(ctx, clone.Retry{}, url, dir, ref, true); err != nil {
-			fmt.Fprintf(os.Stderr, "  clone: %v\n", err)
+		repositoryURL, ref := splitDependentSpec(spec)
+		if err := validateRepositoryURL(repositoryURL); err != nil {
+			fmt.Fprintf(os.Stderr, "  dependent rejected: %s\n", safeLine(err.Error()))
+			corpusErrs = append(corpusErrs, err)
+			continue
+		}
+		display := clone.RedactURL(repositoryURL)
+		fmt.Fprintf(os.Stderr, "▶ dependent %s\n", safeLine(display))
+		dir := filepath.Join(*work, "targets", slugify(repositoryURL))
+		if err := clone.Ensure(ctx, clone.Retry{}, repositoryURL, dir, ref, true); err != nil {
+			fmt.Fprintf(os.Stderr, "  clone: %s\n", safeLine(err.Error()))
 			corpusErrs = append(corpusErrs, fmt.Errorf("%s: clone: %w", display, err))
 			continue
 		}
 		// corpus owns this clone (unlike gen's symlinked target), so agent
 		// directive files can be removed before the skill run reads it.
 		if n, err := harness.StripDirectives(dir); err != nil {
-			fmt.Fprintf(os.Stderr, "  strip: %v\n", err)
+			fmt.Fprintf(os.Stderr, "  strip: %s\n", safeLine(err.Error()))
 			corpusErrs = append(corpusErrs, fmt.Errorf("%s: strip: %w", display, err))
 			continue
 		} else if n > 0 {
@@ -88,22 +104,33 @@ func cmdCorpus(ctx context.Context, args []string) error {
 		}
 		t, err := hyrum.Analyze(dir)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  analyze: %v\n", err)
+			fmt.Fprintf(os.Stderr, "  analyze: %s\n", safeLine(err.Error()))
 			corpusErrs = append(corpusErrs, fmt.Errorf("%s: analyze: %w", display, err))
 			continue
 		}
 		d, ok := findDep(t, *upstream)
 		if !ok {
-			fmt.Fprintf(os.Stderr, "  %s does not use %s; skipping\n", url, *upstream)
+			fmt.Fprintf(os.Stderr, "  %s does not use %s; skipping\n", safeLine(display), safeLine(*upstream))
 			corpusErrs = append(corpusErrs, fmt.Errorf("%s: does not use %s", display, *upstream))
 			continue
 		}
 		if err := p.genAll(ctx, t, []hyrum.Dep{d}); err != nil {
-			fmt.Fprintf(os.Stderr, "  %v\n", err)
+			fmt.Fprintf(os.Stderr, "  %s\n", safeLine(err.Error()))
 			corpusErrs = append(corpusErrs, fmt.Errorf("%s: generate: %w", display, err))
 		}
 	}
 	return errors.Join(corpusErrs...)
+}
+
+func validateRepositoryURL(repositoryURL string) error {
+	parsed, err := url.Parse(repositoryURL)
+	if err != nil {
+		return fmt.Errorf("invalid repository URL")
+	}
+	if parsed.User != nil {
+		return fmt.Errorf("repository URL must not contain embedded credentials; use a Git credential helper")
+	}
+	return nil
 }
 
 // discoverDependents queries ecosyste.ms via git-pkgs/dependents for the
@@ -119,6 +146,9 @@ func discoverDependents(ctx context.Context, rc *registries.Client, upstream, re
 	}
 	if repo == "" {
 		return nil, fmt.Errorf("no repository URL for %s (pass --upstream-repo)", upstream)
+	}
+	if err := validateRepositoryURL(repo); err != nil {
+		return nil, err
 	}
 	ec, err := enrichment.NewEcosystemsClient()
 	if err != nil {
@@ -146,7 +176,11 @@ func discoverDependents(ctx context.Context, rc *registries.Client, upstream, re
 			continue
 		}
 		out = append(out, c.Repository)
-		fmt.Fprintf(os.Stderr, "  discovered %s (score %d)\n", c.Repository, dependents.PopularityScore(c))
+		display := "[invalid repository URL]"
+		if validateRepositoryURL(c.Repository) == nil {
+			display = clone.RedactURL(c.Repository)
+		}
+		fmt.Fprintf(os.Stderr, "  discovered %s (score %d)\n", safeLine(display), dependents.PopularityScore(c))
 		if len(out) >= n {
 			break
 		}

--- a/cmd/hyrum/corpus_test.go
+++ b/cmd/hyrum/corpus_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
@@ -36,21 +38,52 @@ func TestCmdCorpusReturnsAllDependentFailures(t *testing.T) {
 	}
 }
 
-func TestCmdCorpusRedactsDependentCredentialsInErrors(t *testing.T) {
-	const spec = "https://secret@example.com/owner/repo@bad ref"
-	err := cmdCorpus(t.Context(), []string{
-		"--upstream", "pkg:npm/example",
-		"--out", t.TempDir(),
-		"--work", t.TempDir(),
-		"--dependent", spec,
-	})
-	if err == nil {
-		t.Fatal("cmdCorpus accepted an invalid dependent ref")
+func TestCmdCorpusRejectsEmbeddedDependentCredentialsWithoutEchoingThem(t *testing.T) {
+	for _, spec := range []string{
+		"https://secret@example.com/owner/repo",
+		"https://user:secret@example.com/owner/repo@main",
+		"https://user:sec%72et@example.com/owner/repo",
+		"https://user:sec%ZZret@example.com/owner/repo",
+	} {
+		stderr, err := captureStderr(t, func() error {
+			return cmdCorpus(t.Context(), []string{
+				"--upstream", "pkg:npm/example",
+				"--out", t.TempDir(),
+				"--work", t.TempDir(),
+				"--dependent", spec,
+			})
+		})
+		if err == nil || (!strings.Contains(err.Error(), "credential helper") && !strings.Contains(err.Error(), "invalid repository URL")) {
+			t.Fatalf("cmdCorpus(%q) error = %v", spec, err)
+		}
+		if strings.Contains(err.Error(), "secret") || strings.Contains(err.Error(), "sec%72et") || strings.Contains(err.Error(), "sec%ZZret") {
+			t.Fatalf("cmdCorpus error exposed URL credentials: %q", err)
+		}
+		if strings.Contains(stderr, "secret") || strings.Contains(stderr, "sec%72et") || strings.Contains(stderr, "sec%ZZret") {
+			t.Fatalf("cmdCorpus stderr exposed URL credentials: %q", stderr)
+		}
 	}
-	if strings.Contains(err.Error(), "secret") {
-		t.Fatalf("cmdCorpus error exposed URL credentials: %q", err)
+}
+
+func captureStderr(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "REDACTED") {
-		t.Fatalf("cmdCorpus error did not identify the redacted dependent: %q", err)
+	original := os.Stderr
+	os.Stderr = writer
+	runErr := run()
+	os.Stderr = original
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
 	}
+	body, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return string(body), runErr
 }

--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -70,7 +70,7 @@ func defaultGenOptions() genOptions {
 	return genOptions{
 		backend:      defaultGenBackend,
 		out:          defaultGenOut,
-		work:         filepath.Join(os.TempDir(), "hyrum"),
+		work:         defaultWorkPath("work"),
 		outlineBytes: defaultOutlineBytes,
 	}
 }
@@ -154,6 +154,11 @@ func cmdGen(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
+	if !set["work"] && (!set["config"] || cfg.Work == nil) {
+		if err := ensurePrivateWorkRoot(resolved.work); err != nil {
+			return err
+		}
+	}
 
 	selected := selectGenDeps(t, deps, cfg.Deps)
 	if len(selected) == 0 {
@@ -190,7 +195,7 @@ func resolveGenOptions(targetRoot, configPath string, explicitConfig bool, cfg h
 	resolved := defaultGenOptions()
 	resolved.out = outRoot(targetRoot, resolved.out)
 
-	if cfg.Backend != nil {
+	if explicitConfig && cfg.Backend != nil {
 		resolved.backend = *cfg.Backend
 	}
 	if cfg.Out != nil {
@@ -213,7 +218,9 @@ func resolveGenOptions(targetRoot, configPath string, explicitConfig bool, cfg h
 	if cfg.TargetName != nil {
 		resolved.targetName = *cfg.TargetName
 	}
-	resolved.models = cfg.Models
+	if explicitConfig {
+		resolved.models = cfg.Models
+	}
 
 	if set["backend"] {
 		resolved.backend = cli.backend
@@ -423,7 +430,7 @@ func (p *pipeline) genAll(ctx context.Context, t *hyrum.Target, deps []hyrum.Dep
 	for _, d := range deps {
 		if err := p.genOne(ctx, t, idx, d); err != nil {
 			depErr := fmt.Errorf("%s: %w", d.Name, err)
-			fmt.Fprintf(os.Stderr, "  %v\n", depErr)
+			fmt.Fprintf(os.Stderr, "  %s\n", safeLine(depErr.Error()))
 			genErrs = append(genErrs, depErr)
 		}
 	}
@@ -444,7 +451,8 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if err := validateRelativePath("dependency name", d.Name); err != nil {
 		return err
 	}
-	ws := filepath.Join(p.work, targetDir, d.Ecosystem, d.Name)
+	wsRel := filepath.Join(targetDir, d.Ecosystem, d.Name)
+	ws := filepath.Join(p.work, wsRel)
 	if !pathWithinResolved(p.work, ws) {
 		return fmt.Errorf("dependency %q resolves outside work root %q", d.Name, p.work)
 	}
@@ -453,16 +461,22 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if !pathWithinResolved(p.outRoot, outDir) {
 		return fmt.Errorf("dependency %q resolves outside output root %q", d.Name, p.outRoot)
 	}
-	if err := prepareWorkspace(ws); err != nil {
+	preparedWS, err := prepareWorkspaceUnder(p.work, wsRel)
+	if err != nil {
 		return fmt.Errorf("prepare workspace: %w", err)
 	}
-	staged, err := stageContext(ctx, t, targetDir, d, ws, p.rc, p.usageOptions, p.symbols, p.outlineBytes)
+	ws = preparedWS
+	depCheckout, err := prepareExternalCheckout(p.work, filepath.Join(".deps", d.Ecosystem, d.Name))
+	if err != nil {
+		return fmt.Errorf("prepare dependency checkout: %w", err)
+	}
+	staged, err := stageContext(ctx, t, targetDir, d, ws, depCheckout, p.rc, p.usageOptions, p.symbols, p.outlineBytes)
 	if err != nil {
 		return fmt.Errorf("stage: %w", err)
 	}
 	var batches []*usage.Surface
 	if p.batchingEnabled() {
-		surface, err := readUsageSurface(filepath.Join(ws, "usage.json"))
+		surface, err := readUsageSurface(ws, "usage.json")
 		if err != nil {
 			return fmt.Errorf("read staged usage: %w", err)
 		}
@@ -474,11 +488,11 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	historyDep := d
 	historyDep.Version = staged.Baseline
 	if err := hyrum.GatherHistory(ctx, idx, historyDep, staged.DepDir, staged.Latest, ws); err != nil {
-		fmt.Fprintf(os.Stderr, "  %s: history: %v\n", d.Name, err)
+		fmt.Fprintf(os.Stderr, "  %s: history: %s\n", safeLine(d.Name), safeLine(err.Error()))
 	}
 	if !p.run {
 		if p.batchingEnabled() {
-			fmt.Printf("staged %s: %d batch(es) under %s; --run executes and merges them\n", d.Name, len(batches), filepath.Join(ws, "batches"))
+			fmt.Printf("staged %s: %d batch(es) under %s; --run executes and merges them\n", safeLine(d.Name), len(batches), safeLine(filepath.Join(ws, "batches")))
 			return nil
 		}
 		last := skillSteps[len(skillSteps)-1]
@@ -486,14 +500,14 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 			Workspace: ws, SrcDir: hyrum.TargetSubdir, SkillName: last.name,
 			OutputFile: last.out, Model: p.models[last.name], MaxTurns: last.maxTurns,
 		}
-		fmt.Printf("staged %s: %s %v\n", d.Name, p.h.Binary(), p.h.Args(job))
+		fmt.Printf("staged %s: %s %s\n", safeLine(d.Name), safeLine(p.h.Binary()), safeLine(fmt.Sprint(p.h.Args(job))))
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "→ %s ← %s (%s)\n", d.Name, targetDir, d.PURL)
+	fmt.Fprintf(os.Stderr, "→ %s ← %s (%s)\n", safeLine(d.Name), safeLine(targetDir), safeLine(d.PURL))
 	runner := p.runner
 	if runner == nil {
-		runner = hyrum.ContainerRunner{Image: p.containerImage, TargetPath: t.Path}
+		runner = hyrum.ContainerRunner{Image: p.containerImage, TargetPath: t.Path, DependencyPath: staged.DepDir}
 	}
 	execution, err := p.runSelectedGeneration(ctx, runner, ws, d.Name, batches)
 	if err != nil {
@@ -517,7 +531,7 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 		meta["verify"] = verify
 		v, cost, recovery, err := p.runValidate(ctx, runner, ws, verify)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "  validate: %v\n", err)
+			fmt.Fprintf(os.Stderr, "  validate: %s\n", safeLine(err.Error()))
 		} else if v != nil {
 			if recovery != "" {
 				recoveredSteps = append(recoveredSteps, "hyrum-validate")
@@ -532,7 +546,7 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	if err := writeJSONUnder(p.outRoot, outRel, "meta.json", meta); err != nil {
 		return err
 	}
-	fmt.Printf("%s ← %s: %d file(s) → %s ($%.4f)\n", d.Name, targetDir, len(written), outDir, totalCost)
+	fmt.Printf("%s ← %s: %d file(s) → %s ($%.4f)\n", safeLine(d.Name), safeLine(targetDir), len(written), safeLine(outDir), totalCost)
 	return nil
 }
 
@@ -583,23 +597,11 @@ var transientWorkspaceFiles = []string{
 	"schema.json",
 }
 
-var transientWorkspaceDirs = []string{"batches"}
+var transientWorkspaceDirs = []string{"batches", "dep", "verify"}
 
 func prepareWorkspace(ws string) error {
-	if err := os.MkdirAll(ws, 0o755); err != nil {
-		return err
-	}
-	for _, name := range transientWorkspaceFiles {
-		if err := os.Remove(filepath.Join(ws, name)); err != nil && !os.IsNotExist(err) {
-			return fmt.Errorf("remove stale %s: %w", name, err)
-		}
-	}
-	for _, name := range transientWorkspaceDirs {
-		if err := os.RemoveAll(filepath.Join(ws, name)); err != nil {
-			return fmt.Errorf("remove stale %s: %w", name, err)
-		}
-	}
-	return nil
+	_, err := prepareWorkspaceUnder(filepath.Dir(ws), filepath.Base(ws))
+	return err
 }
 
 func addBackendRecoveries(meta map[string]any, steps []string) {
@@ -645,11 +647,11 @@ func (p *pipeline) runGenerationStep(
 		Model: p.models[step.name], MaxTurns: step.maxTurns,
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "  %s/%s: %v\n", depName, step.name, err)
+		fmt.Fprintf(os.Stderr, "  %s/%s: %s\n", safeLine(depName), safeLine(step.name), safeLine(err.Error()))
 		return nil, err
 	}
 	if result.BackendError != "" {
-		fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", depName, step.name, result.BackendError)
+		fmt.Fprintf(os.Stderr, "  ! %s/%s: %s\n", safeLine(depName), safeLine(step.name), safeLine(result.BackendError))
 	}
 	return result, nil
 }
@@ -690,7 +692,7 @@ func (p *pipeline) runValidate(ctx context.Context, runner hyrum.Runner, ws stri
 	if !anyRan(verify) {
 		return nil, 0, "", nil
 	}
-	if err := writeJSON(filepath.Join(ws, "verify.json"), verify); err != nil {
+	if err := writeWorkspaceJSON(ws, "verify.json", verify); err != nil {
 		return nil, 0, "", err
 	}
 	fmt.Fprintf(os.Stderr, "  [hyrum-validate]\n")
@@ -699,7 +701,7 @@ func (p *pipeline) runValidate(ctx context.Context, runner hyrum.Runner, ws stri
 		return nil, 0, "", err
 	}
 	if r.BackendError != "" {
-		fmt.Fprintf(os.Stderr, "  ! hyrum-validate: %s\n", r.BackendError)
+		fmt.Fprintf(os.Stderr, "  ! hyrum-validate: %s\n", safeLine(r.BackendError))
 	}
 	var out hyrum.ValidateResult
 	if err := r.Decode(&out); err != nil {
@@ -728,9 +730,9 @@ func reportVerdicts(vs []hyrum.Verdict) {
 	by := map[string]int{}
 	for _, v := range vs {
 		by[v.Status]++
-		fmt.Fprintf(os.Stderr, "    %s [%s→%s]: %s\n", v.Test, v.Status, v.Action, v.Reasoning)
+		fmt.Fprintf(os.Stderr, "    %s [%s→%s]: %s\n", safeLine(v.Test), safeLine(v.Status), safeLine(v.Action), safeLine(v.Reasoning))
 	}
-	fmt.Fprintf(os.Stderr, "    validate: %d verdict(s) — %v\n", len(vs), by)
+	fmt.Fprintf(os.Stderr, "    validate: %d verdict(s) — %s\n", len(vs), safeLine(fmt.Sprint(by)))
 }
 
 // runVerify installs the dep at baseline and latest in a scratch dir under
@@ -741,8 +743,10 @@ func (p *pipeline) runVerify(ctx context.Context, ws string, d hyrum.Dep, baseli
 		return []hyrum.VerifyResult{{Error: "baseline version is unresolved"}}
 	}
 	scratch := filepath.Join(ws, "verify")
-	_ = os.RemoveAll(scratch)
-	if err := os.MkdirAll(scratch, 0o755); err != nil {
+	if err := removeWorkspacePath(ws, "verify", true); err != nil {
+		return []hyrum.VerifyResult{{Error: err.Error()}}
+	}
+	if err := makeWorkspaceDirectory(ws, "verify"); err != nil {
 		return []hyrum.VerifyResult{{Error: err.Error()}}
 	}
 	mgr, testCommand, err := verificationRuntime(scratch, d.Ecosystem)
@@ -750,13 +754,13 @@ func (p *pipeline) runVerify(ctx context.Context, ws string, d hyrum.Dep, baseli
 		return []hyrum.VerifyResult{{Error: fmt.Sprintf("verification runtime for %s: %v", d.Ecosystem, err)}}
 	}
 	versions := []string{baseline, latest}
-	fmt.Fprintf(os.Stderr, "  [verify] %s at %v\n", d.Name, versions)
+	fmt.Fprintf(os.Stderr, "  [verify] %s at %s\n", safeLine(d.Name), safeLine(fmt.Sprint(versions)))
 	results := hyrum.VerifyMatrix(ctx, mgr, testCommand, scratch, d.Name, files, versions)
 	for _, r := range results {
 		if r.Error != "" {
-			fmt.Fprintf(os.Stderr, "    %s: error: %s\n", r.Version, r.Error)
+			fmt.Fprintf(os.Stderr, "    %s: error: %s\n", safeLine(r.Version), safeLine(r.Error))
 		} else {
-			fmt.Fprintf(os.Stderr, "    %s: %d pass, %d fail %v\n", r.Version, r.Pass, r.Fail, r.Failed)
+			fmt.Fprintf(os.Stderr, "    %s: %d pass, %d fail %s\n", safeLine(r.Version), r.Pass, r.Fail, safeLine(fmt.Sprint(r.Failed)))
 		}
 	}
 	return results
@@ -850,20 +854,15 @@ func stageContext(
 	target string,
 	d hyrum.Dep,
 	ws string,
+	depCheckout string,
 	rc *registries.Client,
 	usageOptions usage.IndexOptions,
 	symbols []string,
 	outlineBytes int,
 ) (staged stagedDependency, err error) {
 	staged.OutlineBudgetBytes = outlineBytes
-	if err := os.MkdirAll(ws, 0o755); err != nil {
-		return staged, err
-	}
-
 	// Target: symlink so the skill sees the real tree without a copy.
-	targetLink := filepath.Join(ws, hyrum.TargetSubdir)
-	_ = os.Remove(targetLink)
-	if err := os.Symlink(t.Path, targetLink); err != nil {
+	if err := linkWorkspaceDirectory(ws, hyrum.TargetSubdir, t.Path); err != nil {
 		return staged, fmt.Errorf("link target: %w", err)
 	}
 
@@ -876,7 +875,7 @@ func stageContext(
 	if err != nil {
 		return staged, fmt.Errorf("usage: %w", err)
 	}
-	if err := writeJSON(filepath.Join(ws, "usage.json"), surf); err != nil {
+	if err := writeWorkspaceJSON(ws, "usage.json", surf); err != nil {
 		return staged, err
 	}
 
@@ -889,6 +888,37 @@ func stageContext(
 	if rerr != nil {
 		staged.BaselineError = fmt.Sprintf("registry metadata: %v", rerr)
 	}
+	meta, repositoryErr := dependencyMetadata(d, target, outlineBytes, registryInfo, rerr, &staged)
+	if err := writeWorkspaceJSON(ws, "context.json", meta); err != nil {
+		return staged, err
+	}
+	if registryInfo.Repository == "" {
+		return staged, nil
+	}
+	if err := stageDependencySource(ctx, d, ws, depCheckout, registryInfo.Repository, repositoryErr, surf, outlineBytes, &staged, meta); err != nil {
+		return staged, err
+	}
+	return staged, nil
+}
+
+func dependencyMetadata(
+	d hyrum.Dep,
+	target string,
+	outlineBytes int,
+	registryInfo registryDependency,
+	registryErr error,
+	staged *stagedDependency,
+) (map[string]any, error) {
+	repositoryDisplay := ""
+	var repositoryErr error
+	if registryInfo.Repository != "" {
+		repositoryErr = validateRepositoryURL(registryInfo.Repository)
+		if repositoryErr == nil {
+			repositoryDisplay = clone.RedactURL(registryInfo.Repository)
+		} else {
+			repositoryDisplay = "[invalid repository URL]"
+		}
+	}
 	meta := map[string]any{
 		"purl":                 d.PURL,
 		"name":                 d.Name,
@@ -896,46 +926,76 @@ func stageContext(
 		"constraint":           d.Version,
 		"version":              staged.Baseline,
 		"baseline":             staged.Baseline,
-		"repo":                 registryInfo.Repository,
+		"repo":                 repositoryDisplay,
 		"latest":               staged.Latest,
 		"target":               target,
 		"outline_budget_bytes": outlineBytes,
 	}
-	if rerr != nil {
-		meta["registry_error"] = rerr.Error()
+	if registryErr != nil {
+		meta["registry_error"] = registryErr.Error()
 	}
 	if staged.BaselineError != "" {
 		meta["baseline_error"] = staged.BaselineError
-		fmt.Fprintf(os.Stderr, "  %s: baseline: %s\n", d.Name, staged.BaselineError)
+		fmt.Fprintf(os.Stderr, "  %s: baseline: %s\n", safeLine(d.Name), safeLine(staged.BaselineError))
 	}
 	if registryInfo.Repository == "" {
 		staged.OutlineError = "dependency repository URL is unavailable"
 		meta["outline_error"] = staged.OutlineError
-		fmt.Fprintf(os.Stderr, "  %s: outline unavailable: %s\n", d.Name, staged.OutlineError)
+		fmt.Fprintf(os.Stderr, "  %s: outline unavailable: %s\n", safeLine(d.Name), safeLine(staged.OutlineError))
 	}
-	if err := writeJSON(filepath.Join(ws, "context.json"), meta); err != nil {
-		return staged, err
+	return meta, repositoryErr
+}
+
+func stageDependencySource(
+	ctx context.Context,
+	d hyrum.Dep,
+	ws, depCheckout, repository string,
+	repositoryErr error,
+	surf *usage.Surface,
+	outlineBytes int,
+	staged *stagedDependency,
+	meta map[string]any,
+) error {
+	if repositoryErr != nil {
+		staged.OutlineError = repositoryErr.Error()
+		meta["outline_error"] = staged.OutlineError
+		if writeErr := writeWorkspaceJSON(ws, "context.json", meta); writeErr != nil {
+			return writeErr
+		}
+		return nil
 	}
-	if registryInfo.Repository == "" {
-		return staged, nil
-	}
-	staged.DepDir = filepath.Join(ws, "dep")
+	staged.DepDir = depCheckout
 	// Full clone: hyrum-history diffs between version tags and reads
 	// History.md at old refs, which a shallow clone cannot serve. The dep
 	// clone is reused across runs via Ensure so the cost is one-time.
 	// The dep clone and everything derived from it is best-effort: a bad
 	// repository URL from the registry (or none) means the skills run with
 	// usage.json and git-log.txt only.
-	if err := clone.Ensure(ctx, clone.Retry{}, registryInfo.Repository, staged.DepDir, "", true); err != nil {
-		fmt.Fprintf(os.Stderr, "  clone %s: %v (continuing without dep source)\n", registryInfo.Repository, err)
+	if err := clone.Ensure(ctx, clone.Retry{}, repository, staged.DepDir, "", true); err != nil {
+		fmt.Fprintf(os.Stderr, "  clone %s: %s (continuing without dep source)\n", safeLine(clone.RedactURL(repository)), safeLine(err.Error()))
 		staged.OutlineError = fmt.Sprintf("clone dependency source: %v", err)
 		meta["outline_error"] = staged.OutlineError
 		staged.DepDir = ""
-		if writeErr := writeJSON(filepath.Join(ws, "context.json"), meta); writeErr != nil {
-			return staged, writeErr
+		if writeErr := writeWorkspaceJSON(ws, "context.json", meta); writeErr != nil {
+			return writeErr
 		}
-		return staged, nil
+		return nil
 	}
+	if err := linkWorkspaceDirectory(ws, "dep", staged.DepDir); err != nil {
+		return fmt.Errorf("link dependency source: %w", err)
+	}
+	return stageDependencyOutline(ctx, d, ws, surf, outlineBytes, staged, meta)
+}
+
+func stageDependencyOutline(
+	ctx context.Context,
+	d hyrum.Dep,
+	ws string,
+	surf *usage.Surface,
+	outlineBytes int,
+	staged *stagedDependency,
+	meta map[string]any,
+) error {
 	// Outline the dependency at the resolved baseline release so
 	// generated tests reference the baseline API rather than symbols added or
 	// changed since. The working tree is restored afterwards so writeChangelog
@@ -944,37 +1004,37 @@ func stageContext(
 	restore, tag, matched := checkoutVersion(ctx, staged.DepDir, staged.Baseline, d.Ecosystem)
 	if !matched {
 		if _, err := harness.StripDirectives(staged.DepDir); err != nil {
-			return staged, fmt.Errorf("strip %s: %w", staged.DepDir, err)
+			return fmt.Errorf("strip %s: %w", staged.DepDir, err)
 		}
 		if staged.Baseline != "" {
 			staged.OutlineError = fmt.Sprintf("no source tag matched resolved baseline %s", staged.Baseline)
-			fmt.Fprintf(os.Stderr, "  %s: outline unavailable: %s\n", d.Name, staged.OutlineError)
+			fmt.Fprintf(os.Stderr, "  %s: outline unavailable: %s\n", safeLine(d.Name), safeLine(staged.OutlineError))
 		} else {
 			staged.OutlineError = "dependency outline unavailable because the baseline version is unresolved"
 		}
 		meta["outline_error"] = staged.OutlineError
-		if err := writeJSON(filepath.Join(ws, "context.json"), meta); err != nil {
-			return staged, err
+		if err := writeWorkspaceJSON(ws, "context.json", meta); err != nil {
+			return err
 		}
-		return staged, nil
+		return nil
 	}
 	staged.OutlineRef = tag
 	meta["outline_ref"] = tag
 	if _, err := harness.StripDirectives(staged.DepDir); err != nil {
 		restore()
-		return staged, fmt.Errorf("strip %s: %w", staged.DepDir, err)
+		return fmt.Errorf("strip %s: %w", staged.DepDir, err)
 	}
 	res, err := outline.Pack(staged.DepDir, outline.Options{Compress: true, Ignore: depOutlineIgnore})
 	restore()
 	if _, serr := harness.StripDirectives(staged.DepDir); serr != nil {
-		return staged, fmt.Errorf("strip %s: %w", staged.DepDir, serr)
+		return fmt.Errorf("strip %s: %w", staged.DepDir, serr)
 	}
 	if err != nil {
-		return staged, fmt.Errorf("outline: %w", err)
+		return fmt.Errorf("outline: %w", err)
 	}
 	selection, err := selectDependencyOutline(res, surf, outlineBytes)
 	if err != nil {
-		return staged, fmt.Errorf("select dependency outline: %w", err)
+		return fmt.Errorf("select dependency outline: %w", err)
 	}
 	staged.OutlineBytes = selection.RenderedBytes
 	staged.OutlineFiles = len(selection.Included)
@@ -983,16 +1043,16 @@ func stageContext(
 	meta["outline_bytes"] = staged.OutlineBytes
 	meta["outline_files"] = staged.OutlineFiles
 	meta["outline_omitted_files"] = staged.OutlineOmittedFiles
-	if err := writeJSON(filepath.Join(ws, "context.json"), meta); err != nil {
-		return staged, err
+	if err := writeWorkspaceJSON(ws, "context.json", meta); err != nil {
+		return err
 	}
-	if err := writeJSON(filepath.Join(ws, outlineSelectionFile), selection); err != nil {
-		return staged, err
+	if err := writeWorkspaceJSON(ws, outlineSelectionFile, selection); err != nil {
+		return err
 	}
-	if err := os.WriteFile(filepath.Join(ws, "dep-outline.md"), selection.contents, 0o644); err != nil {
-		return staged, err
+	if err := writeWorkspaceFile(ws, "dep-outline.md", selection.contents); err != nil {
+		return err
 	}
-	return staged, nil
+	return nil
 }
 
 // checkoutVersion moves dir's working tree to the git tag matching version and
@@ -1163,17 +1223,6 @@ func dependencyConfigFor(dep hyrum.Dep, overrides map[string]hyrumconfig.Depende
 		override.Activations = byPURL.Activations
 	}
 	return override
-}
-
-func writeJSON(path string, v any) error {
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	enc.SetIndent("", "  ")
-	return enc.Encode(v)
 }
 
 func writeJSONUnder(root, dir, name string, v any) error {

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -123,14 +123,6 @@ func TestPrepareWorkspaceRemovesTransientArtifacts(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	depDir := filepath.Join(ws, "dep")
-	if err := os.Mkdir(depDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	keep := filepath.Join(depDir, "keep")
-	if err := os.WriteFile(keep, nil, 0o644); err != nil {
-		t.Fatal(err)
-	}
 	for _, name := range transientWorkspaceDirs {
 		if err := os.Mkdir(filepath.Join(ws, name), 0o755); err != nil {
 			t.Fatal(err)
@@ -152,9 +144,6 @@ func TestPrepareWorkspaceRemovesTransientArtifacts(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(ws, name)); !os.IsNotExist(err) {
 			t.Errorf("transient directory %q remains: %v", name, err)
 		}
-	}
-	if _, err := os.Stat(keep); err != nil {
-		t.Fatalf("reusable dependency clone was removed: %v", err)
 	}
 }
 
@@ -235,15 +224,18 @@ func TestResolveGenOptionsPrecedence(t *testing.T) {
 	target := t.TempDir()
 	backend, configOut, configWork, configTargetName := "codex", "configured/out", "configured/work", "configured-target"
 	configOutlineBytes := 131072
-	cfg := hyrumconfig.File{Backend: &backend, Out: &configOut, Work: &configWork, TargetName: &configTargetName, OutlineBytes: &configOutlineBytes}
+	cfg := hyrumconfig.File{Backend: &backend, Out: &configOut, Work: &configWork, TargetName: &configTargetName, OutlineBytes: &configOutlineBytes, Models: map[string]string{"hyrum-generate": "max"}}
 
-	t.Run("discovered config cannot set work", func(t *testing.T) {
+	t.Run("discovered config cannot select credential-bearing execution", func(t *testing.T) {
 		got, err := resolveGenOptions(target, configPath, false, cfg, defaultGenOptions(), nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got.backend != "codex" {
+		if got.backend != defaultGenBackend {
 			t.Errorf("backend = %q", got.backend)
+		}
+		if got.models != nil {
+			t.Errorf("models = %v", got.models)
 		}
 		if got.out != filepath.Join(target, configOut) {
 			t.Errorf("out = %q", got.out)
@@ -266,6 +258,9 @@ func TestResolveGenOptionsPrecedence(t *testing.T) {
 		}
 		if got.work != filepath.Join(configDir, configWork) {
 			t.Errorf("work = %q", got.work)
+		}
+		if got.backend != "codex" || got.models["hyrum-generate"] != "max" {
+			t.Errorf("explicit execution config was not applied: %+v", got)
 		}
 	})
 
@@ -544,7 +539,7 @@ func TestCmdGenConfigFileBehavior(t *testing.T) {
 	})
 
 	t.Run("missing automatic is optional", func(t *testing.T) {
-		err := cmdGen(context.Background(), []string{target})
+		err := cmdGen(context.Background(), []string{"--work", t.TempDir(), target})
 		if err == nil || !strings.Contains(err.Error(), "no dependencies selected") {
 			t.Fatalf("error = %v", err)
 		}
@@ -559,6 +554,16 @@ func TestVisitedFlagsRecordsExplicitDefaults(t *testing.T) {
 	}
 	if !visitedFlags(fs)["backend"] {
 		t.Fatal("explicit default-valued flag was not recorded")
+	}
+}
+
+func TestResolveContainerPinsDefaultAndPreservesExplicitImage(t *testing.T) {
+	if got := resolveContainer("default"); got != hyrum.DefaultRunnerImage {
+		t.Fatalf("default image = %q", got)
+	}
+	const custom = "registry.example/runner:v1"
+	if got := resolveContainer(custom); got != custom {
+		t.Fatalf("custom image = %q", got)
 	}
 }
 

--- a/cmd/hyrum/helpers_test.go
+++ b/cmd/hyrum/helpers_test.go
@@ -147,7 +147,7 @@ func TestSplitDependentSpec(t *testing.T) {
 }
 
 func TestIndent(t *testing.T) {
-	if got := indent("a\nb\n", "  "); got != "  a\n  b" {
+	if got := indent("a\nb\n"); got != "  a\n  b" {
 		t.Errorf("got %q", got)
 	}
 }

--- a/cmd/hyrum/main.go
+++ b/cmd/hyrum/main.go
@@ -42,7 +42,7 @@ func run() int {
 	}
 	cmd, ok := commands[args[0]]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "hyrum: unknown subcommand %q\n\n", args[0])
+		fmt.Fprintf(os.Stderr, "hyrum: unknown subcommand %q\n\n", safeLine(args[0]))
 		printUsage()
 		return exitUsage
 	}
@@ -53,7 +53,7 @@ func run() int {
 	defer stop()
 
 	if err := cmd(ctx, args[1:]); err != nil {
-		fmt.Fprintf(os.Stderr, "hyrum %s: %v\n", args[0], err)
+		fmt.Fprintf(os.Stderr, "hyrum %s: %s\n", safeLine(args[0]), safeText(err.Error()))
 		return 1
 	}
 	return 0

--- a/cmd/hyrum/output.go
+++ b/cmd/hyrum/output.go
@@ -1,0 +1,6 @@
+package main
+
+import "github.com/alpha-omega-security/hyrum/internal/terminal"
+
+func safeLine(s string) string { return terminal.SingleLine(s) }
+func safeText(s string) string { return terminal.Multiline(s) }

--- a/cmd/hyrum/surface.go
+++ b/cmd/hyrum/surface.go
@@ -143,8 +143,8 @@ func surfaceSummaryWithOptions(
 	fmt.Fprintln(tw, "DEP\tECOSYSTEM\tVERSION\tSCOPE\tSYMBOLS\tSITES\tPROD\tTEST\tOTHER\tINDEX")
 	for _, r := range rows {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%d\t%d\t%d\t%d\t%d\t%s\n",
-			r.Name, r.Ecosystem, r.Version, r.Scope, r.Symbols, r.Sites,
-			r.ProductionSites, r.TestSites, r.OtherSites, r.Indexer)
+			safeLine(r.Name), safeLine(r.Ecosystem), safeLine(r.Version), safeLine(r.Scope), r.Symbols, r.Sites,
+			r.ProductionSites, r.TestSites, r.OtherSites, safeLine(r.Indexer))
 	}
 	return tw.Flush()
 }
@@ -186,11 +186,11 @@ func surfaceDetailWithOptions(
 	}
 	const contextWidth = 80
 	for _, s := range out {
-		fmt.Printf("# %s (%s) — %d symbols\n", s.Dep, s.Ecosystem, s.UsedCount())
+		fmt.Printf("# %s (%s) — %d symbols\n", safeLine(s.Dep), safeLine(s.Ecosystem), s.UsedCount())
 		for _, sym := range s.Symbols {
-			fmt.Printf("  %s  [%s]  %d site(s)\n", sym.Name, sym.Kind, len(sym.Sites))
+			fmt.Printf("  %s  [%s]  %d site(s)\n", safeLine(sym.Name), safeLine(sym.Kind), len(sym.Sites))
 			for _, site := range sym.Sites {
-				fmt.Printf("    %s:%d  [%s]  %s\n", site.File, site.Line, site.Scope, truncate(site.Context, contextWidth))
+				fmt.Printf("    %s:%d  [%s]  %s\n", safeLine(site.File), site.Line, safeLine(string(site.Scope)), truncate(safeLine(site.Context), contextWidth))
 			}
 		}
 	}
@@ -232,8 +232,9 @@ func findDep(t *hyrum.Target, name string) (hyrum.Dep, bool) {
 }
 
 func truncate(s string, n int) string {
-	if len(s) <= n {
+	runes := []rune(s)
+	if len(runes) <= n {
 		return s
 	}
-	return s[:n-1] + "…"
+	return string(runes[:n-1]) + "…"
 }

--- a/cmd/hyrum/workdir.go
+++ b/cmd/hyrum/workdir.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const privateWorkMode = 0o700
+
+func defaultWorkPath(kind string) string {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(cache, "hyrum", kind)
+}
+
+// ensurePrivateWorkRoot establishes the default cache root before any
+// reusable clone or model-visible workspace is created. Explicit --work paths
+// remain operator-controlled and keep their existing permissions.
+func ensurePrivateWorkRoot(path string) error {
+	if path == "" {
+		return fmt.Errorf("determine user cache directory: no cache directory is available; pass --work explicitly")
+	}
+	if err := os.MkdirAll(path, privateWorkMode); err != nil {
+		return fmt.Errorf("create private work root: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect private work root: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("refusing non-directory default work root %q", path)
+	}
+	if err := os.Chmod(path, privateWorkMode); err != nil {
+		return fmt.Errorf("secure private work root: %w", err)
+	}
+	return nil
+}

--- a/cmd/hyrum/workdir_test.go
+++ b/cmd/hyrum/workdir_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsurePrivateWorkRootCreates0700Directory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "cache", "hyrum")
+	if err := ensurePrivateWorkRoot(path); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o700 {
+		t.Fatalf("mode = %#o, want 0700", got)
+	}
+}
+
+func TestDefaultWorkPathsUseDistinctUserCacheSubdirectories(t *testing.T) {
+	cache, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := defaultWorkPath("work"), filepath.Join(cache, "hyrum", "work"); got != want {
+		t.Fatalf("gen work path = %q, want %q", got, want)
+	}
+	if got, want := defaultWorkPath("corpus"), filepath.Join(cache, "hyrum", "corpus"); got != want {
+		t.Fatalf("corpus work path = %q, want %q", got, want)
+	}
+}
+
+func TestEnsurePrivateWorkRootRejectsSymlink(t *testing.T) {
+	parent := t.TempDir()
+	link := filepath.Join(parent, "work")
+	if err := os.Symlink(t.TempDir(), link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensurePrivateWorkRoot(link); err == nil {
+		t.Fatal("default work root accepted a symlink")
+	}
+}

--- a/cmd/hyrum/workspace.go
+++ b/cmd/hyrum/workspace.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
+)
+
+func writeWorkspaceJSON(ws, name string, value any) error {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return root.WriteJSON(name, value)
+}
+
+func writeWorkspaceFile(ws, name string, data []byte) error {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return root.WriteFile(name, data, 0o644)
+}
+
+func readWorkspaceFile(ws, name string) ([]byte, error) {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = root.Close() }()
+	return root.ReadRegular(name)
+}
+
+func removeWorkspacePath(ws, name string, recursive bool) error {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if recursive {
+		return root.RemoveAll(name)
+	}
+	err = root.Remove(name)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func makeWorkspaceDirectory(ws, name string) error {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	return root.MkdirAll(name, 0o755)
+}
+
+func prepareWorkspaceUnder(workRoot, rel string) (string, error) {
+	root, err := safefs.OpenOrCreate(workRoot, 0o755)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.MkdirAll(rel, 0o755); err != nil {
+		return "", err
+	}
+	workspace, err := root.Sub(rel)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = workspace.Close() }()
+	for _, name := range transientWorkspaceFiles {
+		if err := workspace.Remove(name); err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("remove stale %s: %w", name, err)
+		}
+	}
+	for _, name := range transientWorkspaceDirs {
+		if err := workspace.RemoveAll(name); err != nil {
+			return "", fmt.Errorf("remove stale %s: %w", name, err)
+		}
+	}
+	return workspace.Path(), nil
+}
+
+func prepareExternalCheckout(workRoot, rel string) (string, error) {
+	root, err := safefs.OpenOrCreate(workRoot, 0o755)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.MkdirAll(filepath.Dir(rel), privateWorkMode); err != nil {
+		return "", err
+	}
+	if _, err := root.Lstat(rel); err == nil {
+		sub, err := root.Sub(rel)
+		if err != nil {
+			return "", fmt.Errorf("refusing unsafe dependency checkout %q: %w", rel, err)
+		}
+		_ = sub.Close()
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	return filepath.Join(root.Path(), rel), nil
+}
+
+func linkWorkspaceDirectory(ws, name, target string) error {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.RemoveAll(name); err != nil {
+		return err
+	}
+	return root.Symlink(target, name)
+}

--- a/cmd/hyrum/workspace_test.go
+++ b/cmd/hyrum/workspace_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteWorkspaceJSONReplacesPlantedSymlink(t *testing.T) {
+	ws := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "victim")
+	if err := os.WriteFile(victim, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(ws, "usage.json")
+	if err := os.Symlink(victim, output); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkspaceJSON(ws, "usage.json", map[string]string{"safe": "value"}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(victim); string(got) != "keep" {
+		t.Fatalf("external file changed to %q", got)
+	}
+	if info, err := os.Lstat(output); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("workspace output was not replaced: %v, %v", info, err)
+	}
+}
+
+func TestPrepareWorkspaceUnderRejectsEscapingDirectorySymlink(t *testing.T) {
+	work := t.TempDir()
+	if err := os.Symlink(t.TempDir(), filepath.Join(work, "target")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := prepareWorkspaceUnder(work, filepath.Join("target", "npm", "ws")); err == nil {
+		t.Fatal("workspace creation followed a directory symlink outside the work root")
+	}
+}
+
+func TestLinkWorkspaceDirectoryCreatesExternalInputLink(t *testing.T) {
+	ws := t.TempDir()
+	target := t.TempDir()
+	if err := linkWorkspaceDirectory(ws, "target", target); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.Readlink(filepath.Join(ws, "target"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != target {
+		t.Fatalf("target link = %q, want %q", got, target)
+	}
+}

--- a/docs/consumer-ci.md
+++ b/docs/consumer-ci.md
@@ -20,7 +20,8 @@ The generated files are plain `node:test` (or pytest, or `go test`) files
 under `tests/hyrum/<dep>/from_<target>/` with a `meta.json` recording the
 baseline version and generation inputs. The target component uses the package
 name from one root manifest when available. Nested targets add a stable suffix
-from their Git-relative path, so repeated package names keep separate suites.
+from their Git-relative path, so repeated package
+names keep separate suites.
 `gen --target-name <name>` can
 set it explicitly.
 
@@ -42,12 +43,19 @@ on:
       - package-lock.json
 jobs:
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - run: go install github.com/alpha-omega-security/hyrum/cmd/hyrum@d83039d50e33f85051984fc92e069ec499faa1b0
       - run: hyrum check --dep ws@${{ steps.bump.outputs.version }}
 ```
+
+The read-only job permission and non-persisted checkout credential keep the
+repository token out of reach of dependency code executed by the test runner.
 
 `check` installs the candidate version in a scratch package environment and
 runs `tests/hyrum/ws/`, exiting non-zero with the assertion diff when a pinned
@@ -62,6 +70,13 @@ ws@8.21.3: FAIL
     + Buffer(17) [Uint8Array] [52, 116, 101, 115, 116, ...]
     - '4test pre-encoded'
 ```
+
+Here `PASS` means that the test runner reported no failure. Hyrum always treats
+a non-zero runner exit as an error, even if the output also contains a passing
+summary. It cannot authenticate a verdict emitted by a process that also
+contains dependency code, so `PASS` is not proof that a malicious dependency
+executed every assertion; see the B6 residual in
+[`threatmodel.md`](../threatmodel.md).
 
 The diff names the behaviour (`text message payloads as strings`), the source
 in the project that depends on it (the test's comment cites

--- a/docs/producer-corpus.md
+++ b/docs/producer-corpus.md
@@ -26,6 +26,10 @@ that has moved or been archived. Dependents can also be listed in a
 [ecosyste.ms](https://ecosyste.ms) for the most-used packages depending on
 `ws` and filters out forks and archived repos.
 
+Do not put usernames or tokens in a `--dependent` URL. Hyrum rejects URL
+userinfo before logging, naming, or cloning the repository; configure Git's
+credential helper when a private HTTPS repository needs authentication.
+
 ## Running the corpus against a change
 
 From the library checkout, install the local build and run the corpus:

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -15,8 +15,8 @@ Before any model step runs, `stageContext` and `GatherHistory` write:
 
 | file | source | consumed by |
 |---|---|---|
-| `target/` | symlink to the target repository | usage, generate |
-| `dep/` | full clone of the dependency's source repo (best-effort) | history |
+| `target/` | target repository (host symlink; read-only container mount) | usage, generate |
+| `dep/` | full dependency checkout kept outside the workspace (host symlink; read-only container mount; best-effort) | history, generate |
 | `usage.json` | scoped imports, refs, and configured activation strings over `target/` | usage, generate |
 | `dep-outline.md` | byte-bounded selection from `outline.Pack` of the source tag matching the resolved baseline; absent when no tag matches | usage, generate |
 | `outline-selection.json` | included and omitted outline paths with selection reasons and byte counts | usage, generate, inspection |

--- a/hyrum.sample.yaml
+++ b/hyrum.sample.yaml
@@ -5,11 +5,13 @@
 # which win over built-in defaults. Unknown keys and incorrect types are
 # errors.
 
-# Harness backend for LLM-driven skills.
+# Harness backend for LLM-driven skills. Ignored in an automatically discovered
+# target config; pass --config explicitly to authorize provider selection.
 # backend: claude          # claude | codex | copilot | opencode
 
 # Per-skill model tier. The selected backend maps mid/high/max to its own
-# models. Keys match the model-driven skills under skills/.
+# models. Keys match the model-driven skills under skills/. Also ignored in an
+# automatically discovered target config.
 # models:
 #   hyrum-usage:    mid
 #   hyrum-history:  mid
@@ -31,7 +33,7 @@
 # Working directory for dependency clones and skill workspaces. This setting is
 # ignored when the config is auto-discovered; pass --config explicitly to trust
 # it. Relative paths use the directory containing that explicit config file.
-# work: ~/.cache/hyrum
+# work: ~/.cache/hyrum/work
 
 # Maximum rendered size of each dependency source outline. Hyrum selects whole
 # files related to observed usage and fails before a model run if required

--- a/internal/hyrum/container.go
+++ b/internal/hyrum/container.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 
 	"github.com/alpha-omega-security/harness"
-	"github.com/alpha-omega-security/hyrum/skills"
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
 )
 
 // DefaultRunnerImage bundles the harness backends (claude, codex, opencode),
 // brief, git-pkgs, git, and node/python/go toolchains. It is built from
 // alpha-omega-security/scrutineer/Dockerfile.runner and published per release.
-const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner:latest"
+const DefaultRunnerImage = "ghcr.io/alpha-omega-security/scrutineer-runner@sha256:c3b6361ccf7a8f440f8ccdf13e88ad996fb3b17846bac032e88a9b405b707baa"
 
 // Runner runs one skill and returns its parsed output. HostRunner and
 // ContainerRunner both satisfy it so the pipeline can switch on a flag.
@@ -46,38 +46,40 @@ type ContainerRunner struct {
 	// set, any existing ws/target symlink is removed before the run so the
 	// mount point is clean.
 	TargetPath string
+	// DependencyPath is the host dependency checkout mounted read-only at
+	// /work/dep. It lives outside the writable agent workspace.
+	DependencyPath string
 	// Emit receives parsed backend events; nil uses defaultEmit.
 	Emit func(harness.Event)
 }
 
 func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions) (*RunResult, error) {
-	skillDir, err := skills.Stage(h, ws, name)
-	if err != nil {
-		return nil, fmt.Errorf("stage skill: %w", err)
-	}
-	if b, err := os.ReadFile(filepath.Join(skillDir, "schema.json")); err == nil {
-		_ = os.WriteFile(filepath.Join(ws, "schema.json"), b, 0o644)
-	}
-	if err := harness.WriteSystemPrompt(h, harness.Job{
-		Workspace:    ws,
-		SystemPrompt: headlessSystemPrompt,
-	}); err != nil {
-		return nil, err
-	}
-
 	absWork, err := filepath.Abs(ws)
 	if err != nil {
 		return nil, err
 	}
-	outputPath, err := prepareOutput(absWork, outputFile)
+	workspace, err := safefs.Open(absWork)
+	if err != nil {
+		return nil, fmt.Errorf("open workspace: %w", err)
+	}
+	defer func() { _ = workspace.Close() }()
+	if err := stageSkillFiles(workspace, h, ws, name); err != nil {
+		return nil, err
+	}
+	hostJob := harness.Job{
+		Workspace:    ws,
+		SystemPrompt: headlessSystemPrompt,
+	}
+	if err := stageSystemPrompt(workspace, h, &hostJob); err != nil {
+		return nil, err
+	}
+
+	outputName, err := prepareOutput(workspace, outputFile)
 	if err != nil {
 		return nil, err
 	}
-	if r.TargetPath != "" {
-		_ = os.Remove(filepath.Join(absWork, TargetSubdir))
-		if err := os.MkdirAll(filepath.Join(absWork, TargetSubdir), 0o755); err != nil {
-			return nil, err
-		}
+	if err := r.prepareMountPoints(workspace); err != nil {
+		return nil, err
 	}
 
 	job := harness.Job{
@@ -124,17 +126,7 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 	done := make(chan struct{})
 	go func() {
 		h.ParseStream(pr, func(e harness.Event) {
-			switch e.Kind {
-			case harness.KindResult:
-				cost := e.CostUSD
-				if cost == 0 && model != "" {
-					cost = harness.CostFromUsage(model, e.Usage)
-				}
-				res.CostUSD = cost
-				res.Turns = e.Turns
-			case harness.KindSession:
-				res.SessionID = e.SessionID
-			}
+			recordRunEvent(res, model, e)
 			emit(e)
 		})
 		close(done)
@@ -156,7 +148,28 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 			runErr = fmt.Errorf("%s run: %w: %s", runtime, waitErr, strings.TrimSpace(stderr.String()))
 		}
 	}
-	return finishRun(ctx, res, outputPath, name, outputFile, runErr)
+	return finishRun(ctx, res, workspace, outputName, name, outputFile, runErr)
+}
+
+func (r ContainerRunner) prepareMountPoints(workspace *safefs.Root) error {
+	for _, mount := range []struct {
+		path    string
+		enabled bool
+	}{
+		{path: TargetSubdir, enabled: r.TargetPath != ""},
+		{path: "dep", enabled: r.DependencyPath != ""},
+	} {
+		if !mount.enabled {
+			continue
+		}
+		if err := workspace.RemoveAll(mount.path); err != nil {
+			return err
+		}
+		if err := workspace.MkdirAll(mount.path, 0o755); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // runArgs builds the container-run argv up to and including the image name.
@@ -178,6 +191,10 @@ func (r ContainerRunner) runArgs(absWork, image string, h harness.Harness) []str
 	if r.TargetPath != "" {
 		abs, _ := filepath.Abs(r.TargetPath)
 		args = append(args, "-v", abs+":/work/target:ro")
+	}
+	if r.DependencyPath != "" {
+		abs, _ := filepath.Abs(r.DependencyPath)
+		args = append(args, "-v", abs+":/work/dep:ro")
 	}
 	// Credential and telemetry-suppression env for this backend. harness.Env
 	// returns bare keys for pass-through; expand them from the host env so

--- a/internal/hyrum/container_test.go
+++ b/internal/hyrum/container_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestContainerRunArgs(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
-	r := ContainerRunner{TargetPath: "/repo"}
+	r := ContainerRunner{TargetPath: "/repo", DependencyPath: "/dependency"}
 	h := harness.ClaudeHarness{}
 	args := r.runArgs("/tmp/ws", "img:tag", h)
 	joined := strings.Join(args, " ")
@@ -27,6 +27,7 @@ func TestContainerRunArgs(t *testing.T) {
 		"-v /tmp/ws:/work",
 		"-w /work",
 		"-v /repo:/work/target:ro",
+		"-v /dependency:/work/dep:ro",
 		"-e ANTHROPIC_API_KEY=sk-test",
 		"-- img:tag",
 	} {
@@ -37,6 +38,12 @@ func TestContainerRunArgs(t *testing.T) {
 	// Image is last, after --.
 	if args[len(args)-1] != "img:tag" || args[len(args)-2] != "--" {
 		t.Errorf("image not terminal: %v", args[len(args)-3:])
+	}
+}
+
+func TestDefaultRunnerImageIsDigestPinned(t *testing.T) {
+	if !strings.Contains(DefaultRunnerImage, "@sha256:") || strings.Contains(DefaultRunnerImage, ":latest") {
+		t.Fatalf("default runner image is mutable: %q", DefaultRunnerImage)
 	}
 }
 

--- a/internal/hyrum/history.go
+++ b/internal/hyrum/history.go
@@ -3,14 +3,13 @@ package hyrum
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
 	"github.com/git-pkgs/changelog"
 	"github.com/git-pkgs/purl"
 	"github.com/git-pkgs/vers"
@@ -144,6 +143,10 @@ func matchingChanges(changes []string, name string) []string {
 // the `SHA date subject / body / manifest paths / matching changes / ---`
 // text format the hyrum-history skill reads.
 func (h *HistoryIndex) WriteGitLog(dep, path string) error {
+	return os.WriteFile(path, h.renderGitLog(dep), 0o644)
+}
+
+func (h *HistoryIndex) renderGitLog(dep string) []byte {
 	var b strings.Builder
 	for _, c := range h.For(dep) {
 		fmt.Fprintf(&b, "%s %s %s\n", c.SHA, c.Date, c.Subject)
@@ -163,7 +166,7 @@ func (h *HistoryIndex) WriteGitLog(dep, path string) error {
 		}
 		b.WriteString("---\n")
 	}
-	return os.WriteFile(path, []byte(b.String()), 0o644)
+	return []byte(b.String())
 }
 
 // maxLogRecord bounds a single git-log record (SHA + date + subject + body +
@@ -386,13 +389,22 @@ func manifestPaths(t *Target) []string {
 // file rather than a hard failure, because hyrum-history treats every input
 // as optional.
 func GatherHistory(ctx context.Context, idx *HistoryIndex, d Dep, depDir, latest, ws string) error {
-	if err := idx.WriteGitLog(d.Name, filepath.Join(ws, "git-log.txt")); err != nil {
+	workspace, err := safefs.Open(ws)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = workspace.Close() }()
+	if err := workspace.WriteFile("git-log.txt", idx.renderGitLog(d.Name), 0o644); err != nil {
 		return err
 	}
 	if depDir != "" {
-		writeChangelog(depDir, filepath.Join(ws, "changelog.json"), d.Version, latest)
+		if entries, ok := readChangelog(depDir, d.Version, latest); ok {
+			_ = workspace.WriteJSON("changelog.json", entries)
+		}
 	}
-	writeVulns(ctx, d.PURL, filepath.Join(ws, "vulns.json"))
+	if summaries, ok := readVulns(ctx, d.PURL); ok {
+		_ = workspace.WriteJSON("vulns.json", summaries)
+	}
 	return nil
 }
 
@@ -402,10 +414,10 @@ type changelogEntry struct {
 	Body    string `json:"body"`
 }
 
-func writeChangelog(depDir, out, from, to string) {
+func readChangelog(depDir, from, to string) ([]changelogEntry, bool) {
 	p, err := changelog.FindAndParse(depDir)
 	if err != nil || p == nil {
-		return
+		return nil, false
 	}
 	// When both endpoints look like exact versions that could appear as
 	// changelog headers, slice to the range so hyrum-history reads only
@@ -413,8 +425,7 @@ func writeChangelog(depDir, out, from, to string) {
 	// every entry the file has.
 	if isExactVersion(from) && isExactVersion(to) {
 		if body, ok := p.Between(from, to); ok && body != "" {
-			writeJSONFile(out, []changelogEntry{{Version: from + ".." + to, Body: body}})
-			return
+			return []changelogEntry{{Version: from + ".." + to, Body: body}}, true
 		}
 	}
 	var entries []changelogEntry
@@ -429,7 +440,7 @@ func writeChangelog(depDir, out, from, to string) {
 		}
 		entries = append(entries, changelogEntry{Version: v, Date: date, Body: e.Content})
 	}
-	writeJSONFile(out, entries)
+	return entries, true
 }
 
 // isExactVersion reports whether v is a single resolved version rather than a
@@ -439,29 +450,30 @@ func isExactVersion(v string) bool {
 	return err == nil && (c.Operator == "" || c.Operator == "=") && c.Version != "*"
 }
 
-func writeVulns(ctx context.Context, purlStr, out string) {
+type vulnerabilitySummary struct {
+	ID       string   `json:"id"`
+	Summary  string   `json:"summary"`
+	Aliases  []string `json:"aliases,omitempty"`
+	Severity string   `json:"severity,omitempty"`
+	Fixed    string   `json:"fixed,omitempty"`
+}
+
+func readVulns(ctx context.Context, purlStr string) ([]vulnerabilitySummary, bool) {
 	if purlStr == "" {
-		return
+		return nil, false
 	}
 	p, err := purl.Parse(purlStr)
 	if err != nil {
-		return
+		return nil, false
 	}
 	src := osv.New()
 	list, err := src.Query(ctx, p)
 	if err != nil || len(list) == 0 {
-		return
+		return nil, false
 	}
-	type v struct {
-		ID       string   `json:"id"`
-		Summary  string   `json:"summary"`
-		Aliases  []string `json:"aliases,omitempty"`
-		Severity string   `json:"severity,omitempty"`
-		Fixed    string   `json:"fixed,omitempty"`
-	}
-	slim := make([]v, 0, len(list))
+	slim := make([]vulnerabilitySummary, 0, len(list))
 	for _, x := range list {
-		slim = append(slim, v{
+		slim = append(slim, vulnerabilitySummary{
 			ID:       x.ID,
 			Summary:  x.Summary,
 			Aliases:  x.Aliases,
@@ -469,7 +481,7 @@ func writeVulns(ctx context.Context, purlStr, out string) {
 			Fixed:    x.FixedVersion(p.Type, p.Name),
 		})
 	}
-	writeJSONFile(out, slim)
+	return slim, true
 }
 
 func severityOf(x vulns.Vulnerability) string {
@@ -477,12 +489,4 @@ func severityOf(x vulns.Vulnerability) string {
 		return s
 	}
 	return ""
-}
-
-func writeJSONFile(path string, v any) {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return
-	}
-	_ = os.WriteFile(path, b, 0o644)
 }

--- a/internal/hyrum/run.go
+++ b/internal/hyrum/run.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/alpha-omega-security/harness"
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
+	"github.com/alpha-omega-security/hyrum/internal/terminal"
 	"github.com/alpha-omega-security/hyrum/skills"
 )
 
@@ -93,15 +95,13 @@ func RunSkillWithEmit(ctx context.Context, h harness.Harness, ws, name, outputFi
 }
 
 func runSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions, emit func(harness.Event)) (*RunResult, error) {
-	skillDir, err := skills.Stage(h, ws, name)
+	workspace, err := safefs.Open(ws)
 	if err != nil {
-		return nil, fmt.Errorf("stage skill: %w", err)
+		return nil, fmt.Errorf("open workspace: %w", err)
 	}
-	// SKILL.md files reference schema.json at the workspace root while the
-	// backend discovers the skill under SkillDir. Mirror the schema so the
-	// path in the instructions is correct regardless of backend layout.
-	if b, err := os.ReadFile(filepath.Join(skillDir, "schema.json")); err == nil {
-		_ = os.WriteFile(filepath.Join(ws, "schema.json"), b, 0o644)
+	defer func() { _ = workspace.Close() }()
+	if err := stageSkillFiles(workspace, h, ws, name); err != nil {
+		return nil, err
 	}
 
 	job := harness.Job{
@@ -113,7 +113,10 @@ func runSkill(ctx context.Context, h harness.Harness, ws, name, outputFile strin
 		Model:        opts.Model,
 		MaxTurns:     opts.MaxTurns,
 	}
-	outputPath, err := prepareOutput(ws, outputFile)
+	if err := stageSystemPrompt(workspace, h, &job); err != nil {
+		return nil, err
+	}
+	outputName, err := prepareOutput(workspace, outputFile)
 	if err != nil {
 		return nil, err
 	}
@@ -130,46 +133,98 @@ func runSkill(ctx context.Context, h harness.Harness, ws, name, outputFile strin
 
 	res := &RunResult{}
 	wrapped := func(e harness.Event) {
-		switch e.Kind {
-		case harness.KindResult:
-			cost := e.CostUSD
-			if cost == 0 && model != "" {
-				cost = harness.CostFromUsage(model, e.Usage)
-			}
-			res.CostUSD = cost
-			res.Turns = e.Turns
-		case harness.KindSession:
-			res.SessionID = e.SessionID
-		}
+		recordRunEvent(res, model, e)
 		if emit != nil {
 			emit(e)
 		}
 	}
 
 	runErr := harness.Run(ctx, h, job, wrapped)
-	return finishRun(ctx, res, outputPath, name, outputFile, runErr)
+	return finishRun(ctx, res, workspace, outputName, name, outputFile, runErr)
+}
+
+func stageSkillFiles(workspace *safefs.Root, h harness.Harness, ws, name string) error {
+	skillDir, err := skills.Stage(h, ws, name)
+	if err != nil {
+		return fmt.Errorf("stage skill: %w", err)
+	}
+	// SKILL.md files reference schema.json at the workspace root while the
+	// backend discovers the skill under SkillDir. Mirror the schema so the
+	// path in the instructions is correct regardless of backend layout.
+	workspaceAbs, workspaceErr := filepath.Abs(workspace.Path())
+	skillDirAbs, skillErr := filepath.Abs(skillDir)
+	if workspaceErr != nil || skillErr != nil {
+		return nil
+	}
+	schemaRel, err := filepath.Rel(workspaceAbs, filepath.Join(skillDirAbs, "schema.json"))
+	if err != nil || !filepath.IsLocal(schemaRel) {
+		return nil
+	}
+	b, err := workspace.ReadRegular(schemaRel)
+	if err != nil {
+		return nil
+	}
+	if err := workspace.WriteFile("schema.json", b, 0o644); err != nil {
+		return fmt.Errorf("stage schema: %w", err)
+	}
+	return nil
+}
+
+func recordRunEvent(result *RunResult, model string, event harness.Event) {
+	switch event.Kind {
+	case harness.KindResult:
+		cost := event.CostUSD
+		if cost == 0 && model != "" {
+			cost = harness.CostFromUsage(model, event.Usage)
+		}
+		result.CostUSD = cost
+		result.Turns = event.Turns
+	case harness.KindSession:
+		result.SessionID = event.SessionID
+	}
+}
+
+func stageSystemPrompt(workspace *safefs.Root, h harness.Harness, job *harness.Job) error {
+	if strings.TrimSpace(job.SystemPrompt) == "" || h.SystemPromptViaArgs() {
+		return nil
+	}
+	guide := h.GuideFilename()
+	if guide == "" || !filepath.IsLocal(guide) {
+		return fmt.Errorf("harness: invalid guide filename %q", guide)
+	}
+	content := job.SystemPrompt
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	if err := workspace.WriteFile(guide, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("harness: write %s: %w", guide, err)
+	}
+	// harness.Run calls WriteSystemPrompt itself. Clearing this field after
+	// safely staging the guide prevents that call from reopening a planted
+	// symlink with os.WriteFile. File-based backends read the staged guide.
+	job.SystemPrompt = ""
+	return nil
 }
 
 // prepareOutput removes the expected artifact before invoking a backend. Skill
 // workspaces are intentionally reusable, so this prevents a failed invocation
 // from appearing successful by leaving an older output file in place.
-func prepareOutput(ws, outputFile string) (string, error) {
+func prepareOutput(workspace *safefs.Root, outputFile string) (string, error) {
 	clean := filepath.Clean(outputFile)
 	if outputFile != clean || clean == "." || clean == ".." || clean != filepath.Base(clean) || filepath.IsAbs(clean) {
 		return "", fmt.Errorf("refusing output path %q", outputFile)
 	}
-	path := filepath.Join(ws, clean)
-	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+	if err := workspace.Remove(clean); err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("remove stale %s: %w", outputFile, err)
 	}
-	return path, nil
+	return clean, nil
 }
 
 // finishRun reads the artifact written by this invocation. A non-zero backend
 // exit is recoverable only when a fresh, usable JSON artifact exists; otherwise
 // the backend error remains fatal. The backend failure is retained on a
 // successful result so callers do not silently treat a partial run as clean.
-func finishRun(ctx context.Context, res *RunResult, outputPath, skillName, outputFile string, runErr error) (*RunResult, error) {
+func finishRun(ctx context.Context, res *RunResult, workspace *safefs.Root, outputName, skillName, outputFile string, runErr error) (*RunResult, error) {
 	if runErr != nil {
 		var accountErr *harness.AccountError
 		if ctx.Err() != nil || errors.As(runErr, &accountErr) {
@@ -177,7 +232,7 @@ func finishRun(ctx context.Context, res *RunResult, outputPath, skillName, outpu
 		}
 	}
 
-	b, err := os.ReadFile(outputPath)
+	b, err := workspace.ReadRegular(outputName)
 	if err != nil {
 		outputErr := fmt.Errorf("read %s: %w (skill did not write output)", outputFile, err)
 		if runErr != nil {
@@ -264,7 +319,7 @@ func writeFilesUnder(root, dir string, files []GeneratedFile, replace bool) ([]s
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, err
 	}
-	outputRoot, err := os.OpenRoot(root)
+	outputRoot, err := safefs.Open(root)
 	if err != nil {
 		return nil, err
 	}
@@ -307,19 +362,12 @@ func defaultEmit(e harness.Event) {
 	case harness.KindThinking:
 		// suppressed
 	case harness.KindTool:
-		fmt.Fprintf(os.Stderr, "  · %s %s\n", e.Tool, firstLine(e.Text))
+		fmt.Fprintf(os.Stderr, "  · %s %s\n", terminal.SingleLine(e.Tool), terminal.SingleLine(e.Text))
 	case harness.KindText:
-		fmt.Fprintf(os.Stderr, "  %s\n", firstLine(e.Text))
+		fmt.Fprintf(os.Stderr, "  %s\n", terminal.SingleLine(e.Text))
 	case harness.KindError:
-		fmt.Fprintf(os.Stderr, "  ! %s\n", e.Text)
+		fmt.Fprintf(os.Stderr, "  ! %s\n", terminal.SingleLine(e.Text))
 	case harness.KindResult:
 		fmt.Fprintf(os.Stderr, "  = %d turns, $%.4f\n", e.Turns, e.CostUSD)
 	}
-}
-
-func firstLine(s string) string {
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
-	}
-	return s
 }

--- a/internal/hyrum/run_test.go
+++ b/internal/hyrum/run_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/alpha-omega-security/harness"
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
 )
 
 // shHarness embeds ClaudeHarness so all interface methods are satisfied, then
@@ -24,6 +25,20 @@ type shHarness struct {
 	noWrite bool
 	stderr  string
 	block   bool
+}
+
+type filePromptHarness struct{ shHarness }
+
+func (filePromptHarness) GuideFilename() string     { return "AGENTS.md" }
+func (filePromptHarness) SystemPromptViaArgs() bool { return false }
+
+type outputSymlinkHarness struct {
+	shHarness
+	target string
+}
+
+func (h outputSymlinkHarness) Args(j harness.Job) []string {
+	return []string{"-c", fmt.Sprintf("ln -s %q %q", h.target, j.OutputFile)}
 }
 
 type recordingHarness struct {
@@ -279,7 +294,12 @@ func TestPrepareOutputRejectsSymlinkedDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := prepareOutput(ws, filepath.Join("sub", "victim.json")); err == nil {
+	root, err := safefs.Open(ws)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer root.Close()
+	if _, err := prepareOutput(root, filepath.Join("sub", "victim.json")); err == nil {
 		t.Fatal("want nested output path rejected")
 	}
 	b, err := os.ReadFile(victim)
@@ -296,6 +316,51 @@ func TestRunSkillMissingOutput(t *testing.T) {
 	h := shHarness{noWrite: true}
 	if _, err := RunSkillWithEmit(context.Background(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
 		t.Fatal("want error when tests.json not written")
+	}
+}
+
+func TestRunSkillReplacesPlantedWorkspaceSymlinks(t *testing.T) {
+	ws := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "victim")
+	if err := os.WriteFile(victim, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := filePromptHarness{shHarness{payload: `{"files":[{"path":"test.js","content":"ok"}]}`}}
+	skillDir := h.SkillDir(ws, "hyrum-generate")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(ws, "AGENTS.md"),
+		filepath.Join(ws, "schema.json"),
+		filepath.Join(skillDir, "SKILL.md"),
+	} {
+		if err := os.Symlink(victim, path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := RunSkillWithEmit(t.Context(), h, ws, "hyrum-generate", "tests.json", nil); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(victim); string(got) != "keep" {
+		t.Fatalf("guide staging changed external file to %q", got)
+	}
+	for _, path := range []string{filepath.Join(ws, "AGENTS.md"), filepath.Join(ws, "schema.json"), filepath.Join(skillDir, "SKILL.md")} {
+		if info, err := os.Lstat(path); err != nil || !info.Mode().IsRegular() {
+			t.Fatalf("%s was not replaced with a regular file: %v, %v", path, info, err)
+		}
+	}
+}
+
+func TestRunSkillRejectsModelOutputSymlink(t *testing.T) {
+	ws := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "secret.json")
+	if err := os.WriteFile(victim, []byte(`{"files":[{"path":"stolen.js","content":"secret"}]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := outputSymlinkHarness{shHarness: shHarness{}, target: victim}
+	if _, err := RunSkillWithEmit(t.Context(), h, ws, "hyrum-generate", "tests.json", nil); err == nil {
+		t.Fatal("model-produced output symlink was accepted")
 	}
 }
 
@@ -319,8 +384,8 @@ func TestWriteFilesRejectsFinalSymlinkEscape(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := WriteFiles(out, []GeneratedFile{{Path: "test.js", Content: "overwritten"}}); err == nil {
-		t.Fatal("WriteFiles followed a final symlink outside the output root")
+	if _, err := WriteFiles(out, []GeneratedFile{{Path: "test.js", Content: "overwritten"}}); err != nil {
+		t.Fatal(err)
 	}
 	body, err := os.ReadFile(victim)
 	if err != nil {
@@ -328,6 +393,9 @@ func TestWriteFilesRejectsFinalSymlinkEscape(t *testing.T) {
 	}
 	if string(body) != "original" {
 		t.Fatalf("outside file changed to %q", body)
+	}
+	if info, err := os.Lstat(filepath.Join(out, "test.js")); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("output was not replaced with a regular file: %v, %v", info, err)
 	}
 }
 

--- a/internal/hyrum/usage/activation_test.go
+++ b/internal/hyrum/usage/activation_test.go
@@ -1,6 +1,10 @@
 package usage
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestIndexRecordsConfiguredActivationStrings(t *testing.T) {
 	root := writeTree(t, map[string]string{
@@ -29,6 +33,47 @@ func TestIndexRecordsConfiguredActivationStrings(t *testing.T) {
 	assertActivationSites(t, production, map[string]Scope{
 		"src/settings.py": ScopeProduction,
 	})
+}
+
+func TestIndexDoesNotReadActivationThroughSourceSymlink(t *testing.T) {
+	root := t.TempDir()
+	secret := filepath.Join(t.TempDir(), "credentials.py")
+	if err := os.WriteFile(secret, []byte("token = \"sk-ant-secret-activation\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(secret, filepath.Join(root, "settings.py")); err != nil {
+		t.Fatal(err)
+	}
+	const dep = "pkg:pypi/example"
+	surface, err := IndexWithOptions(t.Context(), root, dep, IndexOptions{
+		Activations: map[string][]string{dep: {"sk-ant-secret-activation"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(surface.Symbols) != 0 {
+		t.Fatalf("symlinked source was indexed: %+v", surface.Symbols)
+	}
+}
+
+func TestIndexPreservesInTreeSourceSymlink(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "settings.source"), []byte("token = \"in-tree-activation\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("settings.source", filepath.Join(root, "settings.py")); err != nil {
+		t.Fatal(err)
+	}
+	const dep = "pkg:pypi/example"
+	surface, err := IndexWithOptions(t.Context(), root, dep, IndexOptions{
+		Activations: map[string][]string{dep: {"in-tree-activation"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if symbolNames(surface)["in-tree-activation"] != 1 {
+		t.Fatalf("in-tree source symlink was not indexed: %+v", surface.Symbols)
+	}
 }
 
 func TestIndexManyKeepsActivationsWithTheirDependency(t *testing.T) {

--- a/internal/hyrum/usage/index.go
+++ b/internal/hyrum/usage/index.go
@@ -3,12 +3,12 @@ package usage
 import (
 	"context"
 	"io/fs"
-	"os"
 	gopath "path"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
 	"github.com/git-pkgs/outline"
 	"github.com/git-pkgs/provides"
 )
@@ -114,13 +114,18 @@ func scanManyWithOptions(
 	targets []scanTarget,
 	opts IndexOptions,
 ) (map[string]*Surface, error) {
+	targetRoot, err := safefs.Open(root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = targetRoot.Close() }()
 	exts := set(sp.exts...)
 	collectors := make(map[string]*collector, len(targets))
 	for _, target := range targets {
 		collectors[target.key] = newCollector()
 	}
 
-	err := walkSourceFiles(ctx, root, exts, func(path string) error {
+	err = walkSourceFiles(ctx, root, exts, func(path string) error {
 		rel, relErr := filepath.Rel(root, path)
 		if relErr != nil {
 			return nil
@@ -129,7 +134,7 @@ func scanManyWithOptions(
 		if !opts.allows(rel, scope) {
 			return nil
 		}
-		src, rerr := os.ReadFile(path)
+		src, rerr := targetRoot.ReadRegularWithin(rel)
 		if rerr != nil {
 			return nil
 		}

--- a/internal/hyrum/verify.go
+++ b/internal/hyrum/verify.go
@@ -92,7 +92,7 @@ func verifyOne(ctx context.Context, mgr managers.Manager, tc TestCommand, scratc
 	output, runErr := c.CombinedOutput()
 	out := string(output)
 	res.Pass, res.Fail, res.Failed = parseTestOutput(out)
-	if runErr != nil && res.Fail == 0 && res.Pass == 0 {
+	if runErr != nil {
 		res.Error = fmt.Sprintf("%s: %v: %s", argv[0], runErr, tail(out, errorTailBytes))
 	}
 	if res.Fail > 0 || res.Error != "" {

--- a/internal/hyrum/verify_integration_test.go
+++ b/internal/hyrum/verify_integration_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 // TestVerifyMatrixNPM exercises the full scratch-dir + init + add + node --test
-// path against real npm and the ws test file generated in an earlier session
-// run. It is skipped under -short and when npm or the fixture are absent so CI
-// stays hermetic.
+// path against real npm and an explicitly selected, reviewed tests.json
+// fixture. It is skipped under -short and unless the fixture is opted into so
+// an unrelated process cannot plant JavaScript at a predictable shared path.
 func TestVerifyMatrixNPM(t *testing.T) {
 	if testing.Short() {
 		t.Skip("integration")
@@ -22,13 +22,17 @@ func TestVerifyMatrixNPM(t *testing.T) {
 	if _, err := exec.LookPath("npm"); err != nil {
 		t.Skip("npm not on PATH")
 	}
-	body, err := os.ReadFile("/tmp/hyrum/npm/ws/tests.json")
+	fixture := os.Getenv("HYRUM_TEST_NPM_FIXTURE")
+	if fixture == "" {
+		t.Skip("set HYRUM_TEST_NPM_FIXTURE to run the npm integration test")
+	}
+	body, err := os.ReadFile(fixture)
 	if err != nil {
-		t.Skipf("fixture missing: %v", err)
+		t.Fatalf("read HYRUM_TEST_NPM_FIXTURE: %v", err)
 	}
 	var out struct{ Files []GeneratedFile }
 	if err := json.Unmarshal(body, &out); err != nil || len(out.Files) == 0 {
-		t.Skipf("fixture unparseable: %v", err)
+		t.Fatalf("fixture unparseable: %v", err)
 	}
 
 	scratch := t.TempDir()

--- a/internal/hyrum/verify_test.go
+++ b/internal/hyrum/verify_test.go
@@ -3,6 +3,8 @@ package hyrum
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +14,16 @@ import (
 
 type addErrorManager struct {
 	managers.Manager
+}
+
+type addSuccessManager struct {
+	managers.Manager
+}
+
+func (addSuccessManager) Name() string      { return "test" }
+func (addSuccessManager) Ecosystem() string { return "test" }
+func (addSuccessManager) Add(context.Context, string, managers.AddOptions) (*managers.Result, error) {
+	return &managers.Result{}, nil
 }
 
 func (addErrorManager) Name() string      { return "test" }
@@ -25,6 +37,27 @@ func TestVerifyOneHandlesAddErrorWithoutResult(t *testing.T) {
 	if !strings.Contains(result.Error, "invalid package") {
 		t.Fatalf("verifyOne error = %q", result.Error)
 	}
+}
+
+func TestVerifyOneDoesNotTrustForgedPassOnNonzeroExit(t *testing.T) {
+	tc := func(string, []string) []string {
+		return []string{os.Args[0], "-test.run=TestVerifyForgedPassHelper", "--", "forged-pass"}
+	}
+	result := verifyOne(t.Context(), addSuccessManager{}, tc, t.TempDir(), "example", "1.0.0", nil)
+	if result.Pass != 1 {
+		t.Fatalf("control output was not parsed: %+v", result)
+	}
+	if result.Error == "" {
+		t.Fatalf("nonzero runner exit was reported as a pass: %+v", result)
+	}
+}
+
+func TestVerifyForgedPassHelper(t *testing.T) {
+	if len(os.Args) < 2 || os.Args[len(os.Args)-1] != "forged-pass" {
+		return
+	}
+	fmt.Println("pass 1")
+	os.Exit(1)
 }
 
 func TestParseTestOutputNode(t *testing.T) {

--- a/internal/safefs/root.go
+++ b/internal/safefs/root.go
@@ -1,0 +1,237 @@
+// Package safefs provides rooted file operations for directories that may
+// contain paths controlled by an untrusted process.
+package safefs
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Root confines all operations to Path. Call Close when finished.
+type Root struct {
+	path string
+	root *os.Root
+}
+
+// Open opens an existing real directory as a rooted filesystem. The final
+// path itself must not be a symlink.
+func Open(path string) (*Root, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return nil, fmt.Errorf("refusing non-directory root %q", path)
+	}
+	r, err := os.OpenRoot(path)
+	if err != nil {
+		return nil, err
+	}
+	return &Root{path: path, root: r}, nil
+}
+
+// OpenOrCreate creates path when absent and opens it as a rooted filesystem.
+func OpenOrCreate(path string, perm fs.FileMode) (*Root, error) {
+	if err := os.MkdirAll(path, perm); err != nil {
+		return nil, err
+	}
+	return Open(path)
+}
+
+func (r *Root) Close() error { return r.root.Close() }
+func (r *Root) Path() string { return r.path }
+
+func (r *Root) Lstat(name string) (fs.FileInfo, error) {
+	clean, err := local(name)
+	if err != nil {
+		return nil, err
+	}
+	return r.root.Lstat(clean)
+}
+
+func (r *Root) MkdirAll(name string, perm fs.FileMode) error {
+	clean, err := local(name)
+	if err != nil {
+		return err
+	}
+	return r.root.MkdirAll(clean, perm)
+}
+
+// Sub opens name beneath r as a new rooted filesystem.
+func (r *Root) Sub(name string) (*Root, error) {
+	clean, err := local(name)
+	if err != nil {
+		return nil, err
+	}
+	sub, err := r.root.OpenRoot(clean)
+	if err != nil {
+		return nil, err
+	}
+	return &Root{path: filepath.Join(r.path, clean), root: sub}, nil
+}
+
+func (r *Root) Remove(name string) error {
+	clean, err := local(name)
+	if err != nil {
+		return err
+	}
+	return r.root.Remove(clean)
+}
+
+func (r *Root) RemoveAll(name string) error {
+	clean, err := local(name)
+	if err != nil {
+		return err
+	}
+	if clean == "." {
+		return fmt.Errorf("refusing to remove root")
+	}
+	return r.root.RemoveAll(clean)
+}
+
+func (r *Root) Symlink(target, name string) error {
+	clean, err := localFile(name)
+	if err != nil {
+		return err
+	}
+	return r.root.Symlink(target, clean)
+}
+
+// WriteFile atomically replaces name. Replacing the directory entry instead
+// of opening name for writing means a planted final symlink is never followed.
+func (r *Root) WriteFile(name string, data []byte, perm fs.FileMode) error {
+	clean, err := localFile(name)
+	if err != nil {
+		return err
+	}
+	parent := filepath.Dir(clean)
+	if err := r.root.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	tmp, err := temporaryName(parent)
+	if err != nil {
+		return err
+	}
+	f, err := r.root.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return err
+	}
+	removeTemp := true
+	defer func() {
+		_ = f.Close()
+		if removeTemp {
+			_ = r.root.Remove(tmp)
+		}
+	}()
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if err := r.root.Rename(tmp, clean); err != nil {
+		return err
+	}
+	removeTemp = false
+	return nil
+}
+
+func (r *Root) WriteJSON(name string, value any) error {
+	b, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	b = append(b, '\n')
+	return r.WriteFile(name, b, 0o644)
+}
+
+// ReadRegular reads name only when its directory entry is a regular file.
+// os.Root additionally prevents any intermediate symlink from escaping r.
+func (r *Root) ReadRegular(name string) ([]byte, error) {
+	clean, err := localFile(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := r.root.Lstat(clean)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular file %q", name)
+	}
+	f, err := r.root.Open(clean)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err = f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular file %q", name)
+	}
+	return io.ReadAll(f)
+}
+
+// ReadRegularWithin is like ReadRegular but permits symbolic links whose
+// complete resolution remains within r and names a regular file.
+func (r *Root) ReadRegularWithin(name string) ([]byte, error) {
+	clean, err := localFile(name)
+	if err != nil {
+		return nil, err
+	}
+	info, err := r.root.Stat(clean)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular file %q", name)
+	}
+	f, err := r.root.Open(clean)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	info, err = f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("refusing non-regular file %q", name)
+	}
+	return io.ReadAll(f)
+}
+
+func local(name string) (string, error) {
+	clean := filepath.Clean(name)
+	if !filepath.IsLocal(clean) {
+		return "", fmt.Errorf("refusing path %q", name)
+	}
+	return clean, nil
+}
+
+func localFile(name string) (string, error) {
+	clean, err := local(name)
+	if err != nil {
+		return "", err
+	}
+	if clean == "." {
+		return "", fmt.Errorf("refusing file path %q", name)
+	}
+	return clean, nil
+}
+
+func temporaryName(parent string) (string, error) {
+	var id [12]byte
+	if _, err := rand.Read(id[:]); err != nil {
+		return "", err
+	}
+	return filepath.Join(parent, ".hyrum-"+hex.EncodeToString(id[:])+".tmp"), nil
+}

--- a/internal/safefs/root_test.go
+++ b/internal/safefs/root_test.go
@@ -1,0 +1,62 @@
+package safefs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteFileReplacesSymlinkWithoutFollowingIt(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "victim")
+	if err := os.WriteFile(victim, []byte("keep"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, filepath.Join(dir, "output.json")); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	if err := r.WriteFile("output.json", []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := os.ReadFile(victim); string(got) != "keep" {
+		t.Fatalf("external file changed to %q", got)
+	}
+	if info, err := os.Lstat(filepath.Join(dir, "output.json")); err != nil || !info.Mode().IsRegular() {
+		t.Fatalf("output was not replaced by a regular file: %v, %v", info, err)
+	}
+}
+
+func TestReadRegularRejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(t.TempDir(), "secret")
+	if err := os.WriteFile(victim, []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, filepath.Join(dir, "output.json")); err != nil {
+		t.Fatal(err)
+	}
+	r, err := Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	if _, err := r.ReadRegular("output.json"); err == nil {
+		t.Fatal("ReadRegular followed a symlink")
+	}
+}
+
+func TestRootRejectsEscape(t *testing.T) {
+	r, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	if err := r.WriteFile("../outside", []byte("bad"), 0o644); err == nil {
+		t.Fatal("WriteFile accepted an escaping path")
+	}
+}

--- a/internal/terminal/sanitize.go
+++ b/internal/terminal/sanitize.go
@@ -1,0 +1,147 @@
+// Package terminal makes untrusted text safe to print to a terminal while
+// preserving ordinary Unicode text.
+package terminal
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	bellRune              = rune(0x07)
+	escapeRune            = rune(0x1b)
+	deviceControlString   = rune(0x90)
+	startOfString         = rune(0x98)
+	controlSequence       = rune(0x9b)
+	stringTerminator      = rune(0x9c)
+	operatingSystemCmd    = rune(0x9d)
+	privacyMessage        = rune(0x9e)
+	applicationProgramCmd = rune(0x9f)
+)
+
+// SingleLine removes terminal control sequences and returns at most the first
+// logical line. Tabs are rendered as spaces so a value cannot reposition the
+// cursor within a status line.
+func SingleLine(s string) string {
+	return sanitize(s, false)
+}
+
+// Multiline removes terminal control sequences while preserving newlines and
+// tabs for human-readable command output.
+func Multiline(s string) string {
+	return sanitize(s, true)
+}
+
+func sanitize(s string, multiline bool) string {
+	runes := decodeRunes(s)
+	var out strings.Builder
+	for i := 0; i < len(runes); {
+		r := runes[i]
+		switch r {
+		case escapeRune:
+			i = skipEscape(runes, i+1)
+			continue
+		case controlSequence:
+			i = skipCSI(runes, i+1)
+			continue
+		case deviceControlString, startOfString, operatingSystemCmd, privacyMessage, applicationProgramCmd:
+			i = skipControlString(runes, i+1)
+			continue
+		case '\n':
+			if !multiline {
+				return out.String()
+			}
+			out.WriteRune(r)
+			i++
+			continue
+		case '\t':
+			if multiline {
+				out.WriteRune(r)
+			} else {
+				out.WriteByte(' ')
+			}
+			i++
+			continue
+		case '\r':
+			if !multiline {
+				return out.String()
+			}
+			i++
+			continue
+		}
+
+		if r == 0x7f || (r >= 0x80 && r <= 0x9f) ||
+			(r >= 0x202a && r <= 0x202e) || (r >= 0x2066 && r <= 0x2069) ||
+			unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+			i++
+			continue
+		}
+		out.WriteRune(r)
+		i++
+	}
+	return out.String()
+}
+
+func decodeRunes(s string) []rune {
+	out := make([]rune, 0, len(s))
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 && s[0] >= 0x80 && s[0] <= 0x9f {
+			// Preserve raw 8-bit C1 bytes as their control rune so the state
+			// machine removes the entire sequence instead of only its prefix.
+			r = rune(s[0])
+		}
+		out = append(out, r)
+		s = s[size:]
+	}
+	return out
+}
+
+func skipEscape(runes []rune, i int) int {
+	if i >= len(runes) {
+		return i
+	}
+	switch runes[i] {
+	case '[':
+		return skipCSI(runes, i+1)
+	case 'P', 'X', ']', '^', '_':
+		return skipControlString(runes, i+1)
+	}
+	// Fe escapes have a single final byte, optionally preceded by
+	// intermediate bytes in the 0x20-0x2f range.
+	for i < len(runes) {
+		r := runes[i]
+		i++
+		if r >= 0x30 && r <= 0x7e {
+			break
+		}
+	}
+	return i
+}
+
+func skipCSI(runes []rune, i int) int {
+	for i < len(runes) {
+		r := runes[i]
+		i++
+		if r >= 0x40 && r <= 0x7e {
+			break
+		}
+	}
+	return i
+}
+
+func skipControlString(runes []rune, i int) int {
+	for i < len(runes) {
+		switch runes[i] {
+		case bellRune, stringTerminator:
+			return i + 1
+		case escapeRune:
+			if i+1 < len(runes) && runes[i+1] == '\\' {
+				return i + 2
+			}
+		}
+		i++
+	}
+	return i
+}

--- a/internal/terminal/sanitize_test.go
+++ b/internal/terminal/sanitize_test.go
@@ -1,0 +1,31 @@
+package terminal
+
+import "testing"
+
+func TestSingleLineStripsTerminalControls(t *testing.T) {
+	in := "safe\x1b[31mred\x1b[0m\x1b]0;forged title\x07\b\a\u202eTAIL\nforged line"
+	if got, want := SingleLine(in), "saferedTAIL"; got != want {
+		t.Fatalf("SingleLine() = %q, want %q", got, want)
+	}
+}
+
+func TestMultilinePreservesReadableLayout(t *testing.T) {
+	in := "café\tvalue\r\nsecond\x9b31mline\x9b0m"
+	if got, want := Multiline(in), "café\tvalue\nsecondline"; got != want {
+		t.Fatalf("Multiline() = %q, want %q", got, want)
+	}
+}
+
+func TestControlStringsCannotHideFollowingText(t *testing.T) {
+	in := "before\x1bPignored\x1b\\after"
+	if got, want := SingleLine(in), "beforeafter"; got != want {
+		t.Fatalf("SingleLine() = %q, want %q", got, want)
+	}
+}
+
+func TestInvalidUTF8IsNotEmittedVerbatim(t *testing.T) {
+	in := string([]byte{'a', 0xff, 'b'})
+	if got, want := SingleLine(in), "a�b"; got != want {
+		t.Fatalf("SingleLine() = %q, want %q", got, want)
+	}
+}

--- a/skills/embed.go
+++ b/skills/embed.go
@@ -8,10 +8,10 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 
 	"github.com/alpha-omega-security/harness"
+	"github.com/alpha-omega-security/hyrum/internal/safefs"
 )
 
 //go:embed */SKILL.md */schema.json
@@ -22,7 +22,16 @@ var FS embed.FS
 // directory.
 func Stage(h harness.Harness, workspace, name string) (string, error) {
 	dst := h.SkillDir(workspace, name)
-	if err := os.MkdirAll(dst, 0o755); err != nil {
+	rel, err := filepath.Rel(workspace, dst)
+	if err != nil || !filepath.IsLocal(rel) {
+		return "", fmt.Errorf("skill directory %q is outside workspace", dst)
+	}
+	root, err := safefs.Open(workspace)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = root.Close() }()
+	if err := root.MkdirAll(rel, 0o755); err != nil {
 		return "", err
 	}
 	entries, err := fs.ReadDir(FS, name)
@@ -37,7 +46,7 @@ func Stage(h harness.Harness, workspace, name string) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if err := os.WriteFile(filepath.Join(dst, e.Name()), b, 0o644); err != nil {
+		if err := root.WriteFile(filepath.Join(rel, e.Name()), b, 0o644); err != nil {
 			return "", err
 		}
 	}

--- a/threatmodel.md
+++ b/threatmodel.md
@@ -71,9 +71,11 @@ operator's host
 │   ├── https → registry API, osv.dev, ecosyste.ms         (B1)
 │   ├── git clone → dep repo URL from registry             (B2)
 │   ├── git clone → dependent repo URLs from ecosyste.ms   (B2, corpus only)
-│   ├── workspace/ (staged: usage.json, dep-outline.md,
-│   │               context.json, git-log.txt, changelog,
-│   │               vulns.json, dep/ clone, target symlink)
+│   ├── private user-cache root (0700 by default)
+│   │   ├── dependency checkout (outside the agent workspace)
+│   │   └── workspace/ (staged: usage.json, dep-outline.md,
+│   │                   context.json, git-log.txt, changelog,
+│   │                   vulns.json, dep/target links)
 │   │
 │   ├── agent CLI, host mode                               (B3)
 │   │   cwd = workspace, reads all of the above,
@@ -84,6 +86,7 @@ operator's host
 │   │     --security-opt no-new-privileges --user uid:gid
 │   │     -e HOME=/tmp --tmpfs /tmp
 │   │     -v workspace:/work -v target:/work/target:ro
+│   │     -v dependency:/work/dep:ro
 │   │
 │   ├── WriteFiles(--out, tests.json)                      (B4)
 │   │   paths from LLM output → files under --out
@@ -96,21 +99,23 @@ operator's host
 - **B1** hyrum → registry/OSV/ecosyste.ms. HTTPS via `net/http` default
   client. Responses are JSON-decoded into typed structs; no field is
   interpolated into a shell string.
-- **B2** hyrum → git clone. `clone.Ensure` execs `git` with an argv array; the
-  URL is a single argument. `--` is not currently passed, so a URL beginning
-  `-` could be treated as a flag; see T5.
+- **B2** hyrum → git clone. `clone.Ensure` validates HTTPS URLs and execs
+  `git` with an argv array and `--` before the URL and destination; see T5.
 - **B3** agent CLI → workspace. The backend reads every staged file and has
   its Bash/shell tool enabled, so any text in any staged file may steer what
-  it runs; this boundary is where most of the threats below originate.
+  it runs; this boundary is where most of the threats below originate. Host
+  staging uses rooted atomic replacement, and model-produced artifacts must be
+  regular files before the host reads them.
 - **B4** LLM output → filesystem. `WriteFiles` rejects absolute paths, empty
   paths, and any path containing `..`; everything else is joined under
   `--out`. Target, ecosystem, and dependency names used to construct the
   workspace and output directories must also be clean local paths, so
   manifest values cannot move those directories outside `--work` or `--out`.
-- **B5** container → host. `--cap-drop ALL`, `no-new-privileges`, non-root
-  user, tmpfs HOME, workspace bind-mounted read-write, target bind-mounted
-  read-only. Shared kernel with the host (docker/podman namespace isolation);
-  no seccomp profile beyond the runtime default; no egress filter.
+- **B5** container → host. Digest-pinned runner image, `--cap-drop ALL`,
+  `no-new-privileges`, non-root user, tmpfs HOME, workspace bind-mounted
+  read-write, and target and dependency checkouts bind-mounted read-only.
+  Shared kernel with the host (docker/podman namespace isolation); no seccomp
+  profile beyond the runtime default; no egress filter.
 - **B6** generated tests → host. `--verify` and `check` execute LLM-generated
   test files with the ecosystem's test runner as the operator's uid.
 
@@ -163,19 +168,20 @@ enabled, and the same caution applies.
 `tests.json` from `hyrum-generate` contains `{path, content}` pairs.
 `WriteFilesUnder` rejects any `path` that is absolute, empty, or contains `..`
 as a path element, then writes it through an `os.Root` opened at `--out`.
-Final and intermediate symlinks cannot take the write outside that root.
+Final symlinks are atomically replaced and intermediate symlinks cannot take
+the write outside that root.
 
 An automatically discovered `hyrum.yaml` may configure `out`, but Hyrum
 requires that value and its existing symlink prefixes to resolve inside the
 target. External output paths require an operator-supplied `--config`, making
-that trust decision explicit. Hyrum ignores `work` from an automatically
-discovered config; an external work root requires an operator-supplied
-`--work` or explicit `--config`. Relative values in an explicit config use its
-directory, and absolute or `~` values are honored. Dependency-derived
-workspace paths are confined inside that selected work root, and output paths
-are confined inside their selected output root. Symlinks created or replaced
-after validation remain a time-of-check/time-of-use residual; in container
-mode the target mount is read-only during generation.
+that trust decision explicit. Hyrum ignores `backend`, `models`, and `work`
+from an automatically discovered config; selecting a provider credential,
+paid model, or external work root requires an explicit flag or `--config`.
+Relative values in an explicit config use its directory, and absolute or `~`
+values are honored. Dependency-derived workspace paths are confined inside
+that selected work root, and output paths are confined inside their selected
+output root. In container mode the target and dependency mounts are read-only
+during generation.
 
 ### T4: generated tests execute on the host during --verify (medium; residual)
 
@@ -187,9 +193,21 @@ derived from untrusted input, so T1 injection that reaches `tests.json` as
 step itself was containerised. `check` has the same shape against
 already-committed tests, which the operator has presumably reviewed.
 
-No mitigation is in place. Running `--verify` inside the `--container`
-boundary is the intended fix; until it lands, treat `--verify` on the host
-the same as `--run` on the host.
+Hyrum treats a non-zero test-runner exit as an error even when parsed output
+claims that tests passed. This closes the cheap case where passing text masks
+an ordinary runner failure. `gen --verify` also records baseline and latest
+outcomes, so divergence between the two remains useful regression evidence.
+
+The verdict is not authenticated. Dependency code executes in the same
+process as the test framework and can emit runner-native summaries, events, or
+artifacts, or terminate the process with status zero before assertions run.
+Counts and expected-name inventories are forgeable over the same channel and
+do not change that boundary. Accordingly, `PASS` means only that no failure
+was observed; it is not proof that a malicious dependency executed the suite.
+Running verification in a container would contain its host access but would
+not authenticate an in-process verdict. Until dependency execution and
+assertion evaluation are separated by a trusted protocol, treat verification
+as regression detection rather than a security attestation.
 
 ### T5: crafted dependency name or repository URL reaches a subprocess as a flag (low)
 
@@ -224,6 +242,7 @@ extracting that runner into `alpha-omega-security/harness` for shared use is
 | B3 | registry metadata in `context.json` is unfiltered free text | inherent |
 | B5 | container has no egress allowlist | [harness#7](https://github.com/alpha-omega-security/harness/issues/7) |
 | B6 | `--verify` executes generated code on the host | not yet tracked |
+| B6 | dependency and test framework share a forgeable verdict channel; `PASS` means no failure was observed | T4; inherent until execution and assertion evaluation are isolated |
 
 Without `--container`, restrict `--run` and `--verify` to repositories and
 dependencies you have reason to trust.


### PR DESCRIPTION
Host-side file I/O on both sides of the container boundary followed symlinks. The workspace is bind-mounted read-write at /work, so a backend following injected instructions could plant a link there and have hyrum write through it on the host. Source indexing followed links out of the target as well, staging host file contents into usage.json for the model to read, which the read-only target mount was meant to prevent.

A new internal/safefs confines workspace and output operations to a rooted filesystem. Writes land on an O_EXCL temporary and rename over the target, so a planted symlink is replaced rather than followed, and reads reject anything not a regular file. Indexing permits only links resolving inside the target, untrusted text is stripped of terminal controls, and a non-zero runner exit is unconditionally an error.

The threat model records verdict forgery as a B6 residual, since dependency code shares the test process and can emit runner-native summaries or exit zero before assertions run. PASS is now documented as no failure observed. Backend selection from a discovered config requires an explicit --config, credentialed dependent URLs are refused, and the image is digest-pinned. New tests cover rooted escapes, sanitization, and failure output.
