### PR TITLE
Update harness to v0.1.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26
 toolchain go1.26.6
 
 require (
-	github.com/alpha-omega-security/harness v0.1.10
+	github.com/alpha-omega-security/harness v0.1.12
 	github.com/git-pkgs/brief v0.12.0
 	github.com/git-pkgs/changelog v0.2.0
 	github.com/git-pkgs/clone v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/alpha-omega-security/harness v0.1.10 h1:c8EVlJgLQp3akGpw2r450E8+quAFfznwklU4199qhCQ=
-github.com/alpha-omega-security/harness v0.1.10/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
+github.com/alpha-omega-security/harness v0.1.12 h1:fzbVaoGMma0pCt2N7sZYBgzqYKUjLWvymPH5PLIw6QM=
+github.com/alpha-omega-security/harness v0.1.12/go.mod h1:/nym/38ro7lLq4jVmQhYqblV+0uMo3YpeueqaXNMpOs=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bazelbuild/buildtools v0.0.0-20260716142318-04cf7de1434f h1:2mT6QcXmMFtvg7bezs1Fef7nnpJyeCmfWoWNjwtvNZ4=


### PR DESCRIPTION
Updates `github.com/alpha-omega-security/harness` to `v0.1.12`.