### PR TITLE
Adopt shared harness container runner

### DIFF
--- a/cmd/hyrum/gen.go
+++ b/cmd/hyrum/gen.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/alpha-omega-security/harness"
+	harnesscontainer "github.com/alpha-omega-security/harness/container"
 	hyrumconfig "github.com/alpha-omega-security/hyrum/internal/config"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
@@ -367,7 +368,8 @@ type pipeline struct {
 	// containerImage non-empty means the runner is a ContainerRunner and each
 	// genOne call sets its TargetPath to the analysed target so /work/target
 	// is a read-only bind mount instead of a host symlink.
-	containerImage string
+	containerImage   string
+	containerRuntime *harnesscontainer.Runtime
 	// verify runs the generated tests against baseline and latest after
 	// writing them and records results in meta.json.
 	verify bool
@@ -505,9 +507,9 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	}
 
 	fmt.Fprintf(os.Stderr, "→ %s ← %s (%s)\n", safeLine(d.Name), safeLine(targetDir), safeLine(d.PURL))
-	runner := p.runner
-	if runner == nil {
-		runner = hyrum.ContainerRunner{Image: p.containerImage, TargetPath: t.Path, DependencyPath: staged.DepDir}
+	runner, err := p.runnerFor(t.Path, staged.DepDir)
+	if err != nil {
+		return err
 	}
 	execution, err := p.runSelectedGeneration(ctx, runner, ws, d.Name, batches)
 	if err != nil {
@@ -548,6 +550,23 @@ func (p *pipeline) genOne(ctx context.Context, t *hyrum.Target, idx *hyrum.Histo
 	}
 	fmt.Printf("%s ← %s: %d file(s) → %s ($%.4f)\n", safeLine(d.Name), safeLine(targetDir), len(written), safeLine(outDir), totalCost)
 	return nil
+}
+
+func (p *pipeline) runnerFor(targetPath, dependencyPath string) (hyrum.Runner, error) { //nolint:ireturn // Selects a Runner implementation.
+	if p.runner != nil {
+		return p.runner, nil
+	}
+	if p.containerRuntime == nil {
+		runtime, err := hyrum.DetectContainerRuntime("")
+		if err != nil {
+			return nil, err
+		}
+		p.containerRuntime = &runtime
+	}
+	return hyrum.ContainerRunner{
+		Runtime: *p.containerRuntime, Image: p.containerImage,
+		TargetPath: targetPath, DependencyPath: dependencyPath,
+	}, nil
 }
 
 func (p *pipeline) runSelectedGeneration(

--- a/cmd/hyrum/gen_test.go
+++ b/cmd/hyrum/gen_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/alpha-omega-security/harness"
+	harnesscontainer "github.com/alpha-omega-security/harness/container"
 	hyrumconfig "github.com/alpha-omega-security/hyrum/internal/config"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum"
 	"github.com/alpha-omega-security/hyrum/internal/hyrum/usage"
@@ -65,6 +66,22 @@ func TestNewPipelineIndexesProductionUsageByDefault(t *testing.T) {
 	want := []usage.Scope{usage.ScopeProduction}
 	if !reflect.DeepEqual(p.usageOptions.Scopes, want) {
 		t.Errorf("usage scopes = %v, want %v", p.usageOptions.Scopes, want)
+	}
+}
+
+func TestPipelineBuildsContainerRunner(t *testing.T) {
+	runtime := harnesscontainer.Runtime{Bin: "fake", Rootless: true}
+	p := &pipeline{containerImage: "runner:image", containerRuntime: &runtime}
+	runner, err := p.runnerFor("/target", "/dependency")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := runner.(hyrum.ContainerRunner)
+	if !ok {
+		t.Fatalf("runner type = %T", runner)
+	}
+	if got.Runtime != runtime || got.Image != "runner:image" || got.TargetPath != "/target" || got.DependencyPath != "/dependency" {
+		t.Fatalf("runner = %+v", got)
 	}
 }
 

--- a/internal/hyrum/container.go
+++ b/internal/hyrum/container.go
@@ -3,13 +3,10 @@ package hyrum
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/alpha-omega-security/harness"
+	harnesscontainer "github.com/alpha-omega-security/harness/container"
 	"github.com/alpha-omega-security/hyrum/internal/safefs"
 )
 
@@ -40,8 +37,8 @@ func (HostRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, out
 type ContainerRunner struct {
 	// Image is the runner image; empty uses DefaultRunnerImage.
 	Image string
-	// Runtime is the container CLI (docker, podman); empty uses docker.
-	Runtime string
+	// Runtime is the detected container engine; the zero value uses docker.
+	Runtime harnesscontainer.Runtime
 	// TargetPath is the host path to mount read-only at /work/target. When
 	// set, any existing ws/target symlink is removed before the run so the
 	// mount point is clean.
@@ -51,6 +48,18 @@ type ContainerRunner struct {
 	DependencyPath string
 	// Emit receives parsed backend events; nil uses defaultEmit.
 	Emit func(harness.Event)
+}
+
+// DetectContainerRuntime verifies the requested container engine before use.
+func DetectContainerRuntime(prefer string) (harnesscontainer.Runtime, error) {
+	runtime, ok := harnesscontainer.DetectRuntime(prefer)
+	if ok {
+		return runtime, nil
+	}
+	if prefer == "" {
+		prefer = "docker"
+	}
+	return harnesscontainer.Runtime{}, fmt.Errorf("container runtime %q is unavailable", prefer)
 }
 
 func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, name, outputFile string, opts RunOptions) (*RunResult, error) {
@@ -66,24 +75,9 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 	if err := stageSkillFiles(workspace, h, ws, name); err != nil {
 		return nil, err
 	}
-	hostJob := harness.Job{
-		Workspace:    ws,
-		SystemPrompt: headlessSystemPrompt,
-	}
-	if err := stageSystemPrompt(workspace, h, &hostJob); err != nil {
-		return nil, err
-	}
-
-	outputName, err := prepareOutput(workspace, outputFile)
-	if err != nil {
-		return nil, err
-	}
-	if err := r.prepareMountPoints(workspace); err != nil {
-		return nil, err
-	}
 
 	job := harness.Job{
-		Workspace:    "/work",
+		Workspace:    absWork,
 		SrcDir:       TargetSubdir,
 		SkillName:    name,
 		OutputFile:   outputFile,
@@ -91,27 +85,16 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 		Model:        opts.Model,
 		MaxTurns:     opts.MaxTurns,
 	}
-
-	runtime := r.Runtime
-	if runtime == "" {
-		runtime = "docker"
+	if err := stageSystemPrompt(workspace, h, &job); err != nil {
+		return nil, err
 	}
-	image := r.Image
-	if image == "" {
-		image = DefaultRunnerImage
+	outputName, err := prepareOutput(workspace, outputFile)
+	if err != nil {
+		return nil, err
 	}
-
-	args := r.runArgs(absWork, image, h)
-	args = append(args, h.Binary())
-	args = append(args, h.Args(job)...)
-
-	cmd := exec.CommandContext(ctx, runtime, args...)
-	cmd.Env = os.Environ()
-	pr, pw := io.Pipe()
-	var stderr strings.Builder
-	cmd.Stdout = pw
-	cmd.Stderr = io.MultiWriter(pw, &stderr)
-
+	if err := r.prepareMountPoints(workspace); err != nil {
+		return nil, err
+	}
 	model := opts.Model
 	if model == "" {
 		if defs := h.DefaultModels(); len(defs) > 0 {
@@ -123,32 +106,48 @@ func (r ContainerRunner) RunSkill(ctx context.Context, h harness.Harness, ws, na
 		emit = defaultEmit
 	}
 	res := &RunResult{}
-	done := make(chan struct{})
-	go func() {
-		h.ParseStream(pr, func(e harness.Event) {
-			recordRunEvent(res, model, e)
-			emit(e)
-		})
-		close(done)
-	}()
-
-	if err := cmd.Start(); err != nil {
-		_ = pw.Close()
-		<-done
-		return nil, fmt.Errorf("start %s: %w", runtime, err)
+	containerRunner, err := r.runner()
+	if err != nil {
+		return nil, err
 	}
-	waitErr := cmd.Wait()
-	_ = pw.Close()
-	<-done
-	var runErr error
-	if waitErr != nil {
-		if detail := h.AccountErrorText(stderr.String()); detail != "" {
-			runErr = &harness.AccountError{Detail: detail}
-		} else {
-			runErr = fmt.Errorf("%s run: %w: %s", runtime, waitErr, strings.TrimSpace(stderr.String()))
-		}
-	}
+	runErr := containerRunner.Run(ctx, h, job, func(e harness.Event) {
+		recordRunEvent(res, model, e)
+		emit(e)
+	})
 	return finishRun(ctx, res, workspace, outputName, name, outputFile, runErr)
+}
+
+func (r ContainerRunner) runner() (harnesscontainer.Runner, error) {
+	image := r.Image
+	if image == "" {
+		image = DefaultRunnerImage
+	}
+	mounts := make([]harnesscontainer.Mount, 0, 2)
+	if r.TargetPath != "" {
+		target, err := filepath.Abs(r.TargetPath)
+		if err != nil {
+			return harnesscontainer.Runner{}, fmt.Errorf("target mount: %w", err)
+		}
+		mounts = append(mounts, harnesscontainer.Mount{
+			Host: target, Container: "/work/target", ReadOnly: true,
+		})
+	}
+	if r.DependencyPath != "" {
+		dependency, err := filepath.Abs(r.DependencyPath)
+		if err != nil {
+			return harnesscontainer.Runner{}, fmt.Errorf("dependency mount: %w", err)
+		}
+		mounts = append(mounts, harnesscontainer.Mount{
+			Host: dependency, Container: "/work/dep", ReadOnly: true,
+		})
+	}
+	return harnesscontainer.Runner{
+		Runtime:  r.Runtime,
+		Image:    image,
+		Mounts:   mounts,
+		Network:  "bridge", // Model backends need network access.
+		ReadOnly: true,
+	}, nil
 }
 
 func (r ContainerRunner) prepareMountPoints(workspace *safefs.Root) error {
@@ -170,40 +169,4 @@ func (r ContainerRunner) prepareMountPoints(workspace *safefs.Root) error {
 		}
 	}
 	return nil
-}
-
-// runArgs builds the container-run argv up to and including the image name.
-// The workspace is mounted read-write at /work so the skill can write its
-// output file; the target is mounted read-only so its contents cannot be
-// modified and any agent-directive files it contains are inert on a writable
-// path. HOME is a tmpfs so the user's ~/.codex, ~/.claude etc. are absent.
-func (r ContainerRunner) runArgs(absWork, image string, h harness.Harness) []string {
-	args := []string{
-		"run", "--rm",
-		"--cap-drop", "ALL",
-		"--security-opt", "no-new-privileges",
-		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
-		"-e", "HOME=/tmp",
-		"--tmpfs", "/tmp:rw,nosuid,size=256m",
-		"-v", absWork + ":/work",
-		"-w", "/work",
-	}
-	if r.TargetPath != "" {
-		abs, _ := filepath.Abs(r.TargetPath)
-		args = append(args, "-v", abs+":/work/target:ro")
-	}
-	if r.DependencyPath != "" {
-		abs, _ := filepath.Abs(r.DependencyPath)
-		args = append(args, "-v", abs+":/work/dep:ro")
-	}
-	// Credential and telemetry-suppression env for this backend. harness.Env
-	// returns bare keys for pass-through; expand them from the host env so
-	// the value is set inside the container.
-	for _, e := range h.Env("") {
-		if !strings.ContainsRune(e, '=') {
-			e = e + "=" + os.Getenv(e)
-		}
-		args = append(args, "-e", e)
-	}
-	return append(args, "--", image)
 }

--- a/internal/hyrum/container_test.go
+++ b/internal/hyrum/container_test.go
@@ -3,41 +3,50 @@ package hyrum
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/alpha-omega-security/harness"
+	harnesscontainer "github.com/alpha-omega-security/harness/container"
 )
+
+type eventHarness struct{ shHarness }
+
+func (eventHarness) ParseStream(_ io.Reader, emit func(harness.Event)) {
+	emit(harness.Event{Kind: harness.KindResult, CostUSD: 0.25, Turns: 3})
+	emit(harness.Event{Kind: harness.KindSession, SessionID: "session-1"})
+}
 
 func TestContainerRunArgs(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-test")
 	r := ContainerRunner{TargetPath: "/repo", DependencyPath: "/dependency"}
-	h := harness.ClaudeHarness{}
-	args := r.runArgs("/tmp/ws", "img:tag", h)
+	r.Image = "img:tag"
+	args, _ := runContainerAndReadArgs(t, r, shHarness{payload: `{"files":[]}`})
 	joined := strings.Join(args, " ")
 
 	for _, want := range []string{
 		"run --rm",
 		"--cap-drop ALL",
 		"--security-opt no-new-privileges",
+		"--read-only",
 		"-e HOME=/tmp",
-		"--tmpfs /tmp:rw,nosuid,size=256m",
-		"-v /tmp/ws:/work",
+		"--tmpfs /tmp:rw,exec,nosuid,size=256m",
 		"-w /work",
 		"-v /repo:/work/target:ro",
 		"-v /dependency:/work/dep:ro",
-		"-e ANTHROPIC_API_KEY=sk-test",
-		"-- img:tag",
+		"-e ANTHROPIC_API_KEY",
+		"--network bridge",
+		"-- img:tag /bin/sh",
 	} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("missing %q in %q", want, joined)
 		}
 	}
-	// Image is last, after --.
-	if args[len(args)-1] != "img:tag" || args[len(args)-2] != "--" {
-		t.Errorf("image not terminal: %v", args[len(args)-3:])
+	if strings.Contains(joined, "sk-test") {
+		t.Fatalf("credential value exposed in runtime argv: %q", joined)
 	}
 }
 
@@ -47,14 +56,84 @@ func TestDefaultRunnerImageIsDigestPinned(t *testing.T) {
 	}
 }
 
+func TestDetectContainerRuntimeRejectsUnknownRuntime(t *testing.T) {
+	if _, err := DetectContainerRuntime("unknown"); err == nil || !strings.Contains(err.Error(), `"unknown"`) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestContainerRunArgsNoTarget(t *testing.T) {
 	r := ContainerRunner{}
-	args := r.runArgs("/tmp/ws", "img", harness.ClaudeHarness{})
+	r.Image = "img"
+	args, _ := runContainerAndReadArgs(t, r, shHarness{payload: `{"files":[]}`})
 	for _, a := range args {
-		if strings.Contains(a, "/work/target:ro") {
+		if strings.Contains(a, "/work/target") {
 			t.Errorf("target mount present without TargetPath: %v", args)
 		}
 	}
+}
+
+func TestContainerRunnerPreservesEvents(t *testing.T) {
+	var kinds []string
+	runner := ContainerRunner{
+		Image: "img",
+		Emit: func(event harness.Event) {
+			kinds = append(kinds, event.Kind)
+		},
+	}
+	_, result := runContainerAndReadArgs(t, runner, eventHarness{shHarness{payload: `{"files":[]}`}})
+	if result.CostUSD != 0.25 || result.Turns != 3 || result.SessionID != "session-1" {
+		t.Fatalf("result = %+v", result)
+	}
+	if strings.Join(kinds, ",") != "result,session" {
+		t.Fatalf("event kinds = %v", kinds)
+	}
+}
+
+func TestContainerRunnerDockerIntegration(t *testing.T) {
+	image := os.Getenv("HYRUM_TEST_RUNNER_IMAGE")
+	if image == "" {
+		t.Skip("HYRUM_TEST_RUNNER_IMAGE is not set")
+	}
+	runtime, err := DetectContainerRuntime("docker")
+	if err != nil {
+		t.Skip(err)
+	}
+	ws := t.TempDir()
+	runner := ContainerRunner{Runtime: runtime, Image: image}
+	result, err := runner.RunSkill(t.Context(), shHarness{payload: `{"files":[]}`}, ws, "hyrum-generate", "tests.json", RunOptions{})
+	if err != nil {
+		t.Fatalf("RunSkill: %v", err)
+	}
+	if string(result.Output) != `{"files":[]}` {
+		t.Fatalf("output = %s", result.Output)
+	}
+}
+
+func runContainerAndReadArgs(t *testing.T, runner ContainerRunner, h harness.Harness) ([]string, *RunResult) {
+	t.Helper()
+	ws := t.TempDir()
+	argsPath := filepath.Join(t.TempDir(), "args")
+	t.Setenv("HYRUM_TEST_ARGS", argsPath)
+	t.Setenv("HYRUM_TEST_OUTPUT", filepath.Join(ws, "tests.json"))
+	runtime := filepath.Join(t.TempDir(), "fake-container-runtime")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$HYRUM_TEST_ARGS"
+printf '%s' '{"files":[]}' > "$HYRUM_TEST_OUTPUT"
+`
+	if err := os.WriteFile(runtime, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner.Runtime = harnesscontainer.Runtime{Bin: runtime}
+	result, err := runner.RunSkill(t.Context(), h, ws, "hyrum-generate", "tests.json", RunOptions{})
+	if err != nil {
+		t.Fatalf("RunSkill: %v", err)
+	}
+	b, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(string(b)), "\n"), result
 }
 
 func TestHostRunnerSatisfiesRunner(t *testing.T) {
@@ -76,7 +155,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	runner := ContainerRunner{Runtime: harnesscontainer.Runtime{Bin: runtime}, Image: "test-image"}
 	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	if err != nil {
 		t.Fatalf("fresh valid output should survive container failure: %v", err)
@@ -105,7 +184,7 @@ func TestContainerRunnerBackendFailureDoesNotReuseStaleOutput(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	runner := ContainerRunner{Runtime: harnesscontainer.Runtime{Bin: runtime}, Image: "test-image"}
 	if _, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{}); err == nil {
 		t.Fatal("want error rather than stale container output")
 	}
@@ -129,7 +208,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	runner := ContainerRunner{Runtime: harnesscontainer.Runtime{Bin: runtime}, Image: "test-image"}
 	res, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	if err != nil {
 		t.Fatalf("fresh valid output should survive container failure: %v", err)
@@ -157,7 +236,7 @@ exit 1
 		t.Fatal(err)
 	}
 
-	runner := ContainerRunner{Runtime: runtime, Image: "test-image"}
+	runner := ContainerRunner{Runtime: harnesscontainer.Runtime{Bin: runtime}, Image: "test-image"}
 	_, err := runner.RunSkill(context.Background(), shHarness{}, ws, "hyrum-generate", "tests.json", RunOptions{})
 	var accountErr *harness.AccountError
 	if !errors.As(err, &accountErr) {
@@ -168,7 +247,7 @@ exit 1
 func TestContainerRunnerPassesConfiguredModel(t *testing.T) {
 	ws := t.TempDir()
 	h := &recordingHarness{shHarness: shHarness{payload: `{"files":[]}`}}
-	r := ContainerRunner{Runtime: filepath.Join(t.TempDir(), "missing-runtime")}
+	r := ContainerRunner{Runtime: harnesscontainer.Runtime{Bin: filepath.Join(t.TempDir(), "missing-runtime")}}
 	_, err := r.RunSkill(context.Background(), h, ws, "hyrum-generate", "tests.json", RunOptions{Model: "claude-opus-4-6"})
 	if err == nil {
 		t.Fatal("RunSkill succeeded with missing runtime")


### PR DESCRIPTION
Replace Hyrum’s local container execution with `harness/container.Runner`, preserving staged input and output recovery while using the shared runtime, mount, hardening, and environment handling.

Keep bridge networking explicit so model APIs remain reachable through the proxy, and add an opt-in Docker integration test for the production runner path.

Closes https://github.com/alpha-omega-security/hyrum/issues/32