### PR TITLE
refactor(history): drop the unused WriteGitLog helper

### DIFF
--- a/internal/hyrum/history.go
+++ b/internal/hyrum/history.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -137,13 +136,6 @@ func matchingChanges(changes []string, name string) []string {
 		}
 	}
 	return matches
-}
-
-// WriteGitLog writes the commits for dep from a pre-built index to path in
-// the `SHA date subject / body / manifest paths / matching changes / ---`
-// text format the hyrum-history skill reads.
-func (h *HistoryIndex) WriteGitLog(dep, path string) error {
-	return os.WriteFile(path, h.renderGitLog(dep), 0o644)
 }
 
 func (h *HistoryIndex) renderGitLog(dep string) []byte {

--- a/internal/hyrum/history_test.go
+++ b/internal/hyrum/history_test.go
@@ -141,14 +141,7 @@ func TestBuildHistoryIndexMatchesChangedManifestLinesOnly(t *testing.T) {
 		}
 	}
 
-	out := filepath.Join(t.TempDir(), "git-log.txt")
-	if err := idx.WriteGitLog("ws", out); err != nil {
-		t.Fatal(err)
-	}
-	contents, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatal(err)
-	}
+	contents := idx.renderGitLog("ws")
 	if !strings.Contains(string(contents), `-    "ws": "7.4.2",`) || !strings.Contains(string(contents), `+    "ws": "8.0.0",`) {
 		t.Errorf("git-log.txt lacks matching manifest evidence:\n%s", contents)
 	}


### PR DESCRIPTION
`HistoryIndex.WriteGitLog` lost its last caller when workspace writes moved behind the rooted `safefs` handle, leaving it as the only raw `os.WriteFile` to a caller-supplied path in the package.

Its sole remaining exercise was a test that round-tripped through a temp file; that test now calls `renderGitLog` directly and keeps both rendering assertions. `GatherHistory` is untouched and remains the only writer of `git-log.txt`.
