### PR TITLE
Constrain Renovate Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -35,6 +35,7 @@
       "matchManagers": ["gomod"],
       "groupName": "Go modules",
       "minimumReleaseAge": "7 days",
+      "constraintsFiltering": "strict",
       "postUpdateOptions": ["gomodTidy"]
     },
     {


### PR DESCRIPTION
Renovate currently selects Go module updates before its configured gomodTidy step. Open #47 shows the consequence: two dependency updates rewrite Hyrum's `go` directive from 1.26.0 to 1.26.7 and remove its 1.26.6 toolchain line, silently raising the documented consumer floor inside a dependency PR even though CI remains green.

This enables strict constraint filtering on the Go module rule. Candidate releases that do not support Hyrum's declared Go 1.26.0 floor will now be filtered before Renovate creates an update. The seven-day release age, module grouping, tidy behavior, separate language-version group, manual merge policy, and disabled GitHub Dependency Dashboard remain unchanged; Mend remains the update view. This should land before #47, which Mend can then refresh against the constraint.

The configuration validates against Renovate 44.61.3; JSON parsing and diff checks also pass.

Codex was used to implement this.
