### PR TITLE
Align the preferred Go toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/alpha-omega-security/hyrum
 
 go 1.26.7
 
+toolchain go1.27.1
+
 require (
 	github.com/alpha-omega-security/harness v0.1.12
 	github.com/git-pkgs/brief v0.12.1


### PR DESCRIPTION
Hyrum currently declares Go 1.26.7 as its module compatibility floor but has no preferred toolchain after #47 removed the previous toolchain line. Because CI passes `go.mod` to `actions/setup-go`, it currently exercises Go 1.26.7 while the related Harness and Scrutineer repositories prefer the current Go 1.27 patch release.

This adds `toolchain go1.27.1` while preserving `go 1.26.7`. Consumers retain the same compatibility floor, while local development and standard CI use Go 1.27.1. Existing dependency versions, Renovate constraint filtering, the seven-day release age, manual merges, and the Mend update view remain unchanged. Future preferred-toolchain updates remain visible to Renovate.

The module tidy check, vet, the full race-enabled test suite, and diff checks pass under Go 1.27.1.

Codex was used to implement this.
